### PR TITLE
GUI tree construction integrated into ornl/elision/core

### DIFF
--- a/Elision/src/ElisionGUI/mainGUI.scala
+++ b/Elision/src/ElisionGUI/mainGUI.scala
@@ -275,6 +275,7 @@ class TreeVisPanel extends GamePanel {
 	
 	/** The panel's camera for panning around and zooming in the visualization */
 	val camera = new Camera(0,0,640,480)
+	NodeSprite.camera = camera
 	
 	/** The mouse input interface for the panel */
 	val mouseIn = new MouseInput(this)
@@ -338,6 +339,12 @@ class TreeVisPanel extends GamePanel {
 		
 		//testPaint(g)
 		treeSprite.render(g)
+		
+		// draw the panel's border (used for testing clipping techniques)
+		/*
+		g.setColor(new Color(0xffaaaa))
+		g.drawRect(camera.xLeftEdge.toInt, camera.yTopEdge.toInt, camera.xRightEdge.toInt - camera.xLeftEdge.toInt, camera.yBottomEdge.toInt - camera.yTopEdge.toInt)
+		*/
 		
 		// restore the original transform
 		g.setTransform(origTrans)
@@ -430,7 +437,8 @@ class TreeVisPanel extends GamePanel {
 			camera.zoomAtScreen(0.8, mouseIn.position)
 		
 		// update the camera's transform based on its new state.
-		
+		camera.pWidth = this.size.width
+		camera.pHeight = this.size.height
 		camera.updateTransform
 		
 		// update the mouse's current world coordinates

--- a/Elision/src/ornl/elision/core/AtomSeq.scala
+++ b/Elision/src/ornl/elision/core/AtomSeq.scala
@@ -227,16 +227,31 @@ extends BasicAtom with IndexedSeq[BasicAtom] {
           this, subject)
     }
   }
-
+	
+	//////////////////// GUI changes
   def rewrite(binds: Bindings): (AtomSeq, Boolean) = {
+	// get the node representing this atom that is being rewritten
+	val rwNode = RWTree.current.addChild("AtomSeq rewrite")
+	
     // Rewrite the properties.
+	val propsNode = rwNode.addChild("Properties: ").addChild(props)
+	RWTree.current = propsNode
     val (newprop, pchanged) = props.rewrite(binds)
+	
     // We must rewrite every child atom, and collect them into a new sequence.
+	RWTree.current = rwNode.addChild("Atoms: ")
     val (newseq, schanged) = SequenceMatcher.rewrite(atoms, binds)
+	
     // If anything changed, make a new sequence.
-    if (pchanged || schanged) (new AtomSeq(newprop, newseq), true)
+    if (pchanged || schanged) {
+		RWTree.current = rwNode
+		val newAS = new AtomSeq(newprop, newseq)
+		rwNode.addChild(newAS)
+		(newAS, true)
+	}
     else (this, false)
   }
+  //////////////////// end GUI changes
 
   def toParseString = atoms.mkParseString(props.toParseString + "(" , ", ", ")")
 

--- a/Elision/src/ornl/elision/core/Literal.scala
+++ b/Elision/src/ornl/elision/core/Literal.scala
@@ -243,12 +243,25 @@ extends Literal[BigInt](typ) {
    * Alternate constructor with default `INTEGER` type.
    */
   def this(value: Int) = this(INTEGER, value)
-  def rewrite(binds: Bindings) = theType.rewrite(binds) match {
-	  case (newtype, true) =>
-	    (Literal(newtype, value), true)
-	  case _ =>
-	    (this, false)
+  
+  //////////////////// GUI changes
+  def rewrite(binds: Bindings) = {
+		// get the node representing this atom that is being rewritten
+		val rwNode = RWTree.current
+		RWTree.current = rwNode.addChild(theType)
+		
+		theType.rewrite(binds) match {
+		  case (newtype, true) =>
+			RWTree.current = rwNode
+			val newLit = Literal(newtype, value)
+			rwNode.addChild(newLit)
+			(newLit, true)
+		  case _ =>
+			(this, false)
+		}
 	}
+	//////////////////// end GUI changes
+	
   def toParseString = value.toString +
     (if (typ != INTEGER) ":" + typ.toParseString else "") 
 }
@@ -263,12 +276,25 @@ extends Literal[String](typ) {
    * Alternate constructor with default `STRING` type.
    */
   def this(value: String) = this(STRING, value)
-  def rewrite(binds: Bindings) = theType.rewrite(binds) match {
-	  case (newtype, true) =>
-	    (Literal(newtype, value), true)
-	  case _ =>
-	    (this, false)
+  
+  //////////////////// GUI changes
+  def rewrite(binds: Bindings) = {
+		// get the node representing this atom that is being rewritten
+		val rwNode = RWTree.current
+		RWTree.current = rwNode.addChild(theType)
+		
+		theType.rewrite(binds) match {
+		  case (newtype, true) =>
+			RWTree.current = rwNode
+			val newLit = Literal(newtype, value)
+			rwNode.addChild(newLit)
+			(newLit, true)
+		  case _ =>
+			(this, false)
+		}
 	}
+	//////////////////// end GUI changes
+	
   override def toString = "StringLiteral(" + typ + ", " + toEString(value) + ")"
   def toParseString = toEString(value) +
     (if (typ != STRING) ":" + typ.toParseString else "") 
@@ -284,12 +310,25 @@ extends Literal[Symbol](typ) {
    * Alternate constructor with default `SYMBOL` type.
    */
   def this(value: Symbol) = this(SYMBOL, value)
-  def rewrite(binds: Bindings) = theType.rewrite(binds) match {
-	  case (newtype, true) =>
-	    (Literal(newtype, value), true)
-	  case _ =>
-	    (this, false)
+  
+  //////////////////// GUI changes
+  def rewrite(binds: Bindings) = {
+		// get the node representing this atom that is being rewritten
+		val rwNode = RWTree.current
+		RWTree.current = rwNode.addChild(theType)
+		
+		theType.rewrite(binds) match {
+		  case (newtype, true) =>
+			RWTree.current = rwNode
+			val newLit = Literal(newtype, value)
+			rwNode.addChild(newLit)
+			(newLit, true)
+		  case _ =>
+			(this, false)
+		}
 	}
+	//////////////////// end GUI changes
+	
   override def toString = "SymbolLiteral(" + typ +
   		", Symbol(" + toEString(value.name) + ")"
   def toParseString = toESymbol(value.name) + ":" + typ.toParseString 
@@ -312,12 +351,25 @@ extends Literal[Boolean](typ) {
    * Alternate constructor with default `BOOLEAN` type.
    */
   def this(value: Boolean) = this(BOOLEAN, value)
-  def rewrite(binds: Bindings) = theType.rewrite(binds) match {
-	  case (newtype, true) =>
-	    (Literal(newtype, value), true)
-	  case _ =>
-	    (this, false)
+  
+  //////////////////// GUI changes
+  def rewrite(binds: Bindings) = {
+		// get the node representing this atom that is being rewritten
+		val rwNode = RWTree.current
+		RWTree.current = rwNode.addChild(theType)
+		
+		theType.rewrite(binds) match {
+		  case (newtype, true) =>
+			RWTree.current = rwNode
+			val newLit = Literal(newtype, value)
+			rwNode.addChild(newLit)
+			(newLit, true)
+		  case _ =>
+			(this, false)
+		}
 	}
+	//////////////////// end GUI changes
+	
   override def toParseString = value.toString +
     (if (typ != BOOLEAN) ":" + typ.toParseString else "")
 }
@@ -495,13 +547,24 @@ case class FloatLiteral(typ: BasicAtom, significand: BigInt, exponent: Int,
    */
   def this(significand: BigInt, exponent: Int, radix: Int) =
     this(FLOAT, significand, exponent, radix)
-    
-  def rewrite(binds: Bindings) = theType.rewrite(binds) match {
-	  case (newtype, true) =>
-	    (Literal(newtype, significand, exponent, radix), true)
-	  case _ =>
-	    (this, false)
+	
+	//////////////////// GUI changes
+  def rewrite(binds: Bindings) = {
+		// get the node representing this atom that is being rewritten
+		val rwNode = RWTree.current
+		RWTree.current = rwNode.addChild(theType)
+		
+		theType.rewrite(binds) match {
+		  case (newtype, true) =>
+			RWTree.current = rwNode
+			val newLit = Literal(newtype, significand, exponent, radix)
+			rwNode.addChild(newLit)
+			(newLit, true)
+		  case _ =>
+			(this, false)
+		}
 	}
+	//////////////////// end GUI changes
 }
 
 /**

--- a/Elision/src/ornl/elision/core/RWTreeNode.scala
+++ b/Elision/src/ornl/elision/core/RWTreeNode.scala
@@ -53,6 +53,9 @@ class RWTreeNode(val term : String) {
 	/** String used to display the properties of the atom this node represents. */
 	var properties : String = term
 	
+	/** A Node can be used to represent a comment instead of a type of BasicAtom. This helps to self-document the tree. */
+	var isComment = true
+	
 	/** 
 	 * Auxillary constructor accepting a BasicAtom. 
 	 * It also sets properties to the field values of the BasicAtom.
@@ -75,6 +78,8 @@ class RWTreeNode(val term : String) {
 		properties += "Is constant: " + atom.isConstant + "\n"
 		properties += "Is term: " + atom.isTerm + "\n"
 		
+		isComment = false
+		
 		try {
 			properties += "constant pool: \n"
 			for(i <- atom.constantPool.get) properties += "\t" + i + "\n"
@@ -91,7 +96,24 @@ class RWTreeNode(val term : String) {
 	 */
 	
 	def addChild(node : RWTreeNode) : RWTreeNode = {
-			if(this.term != node.term) {
+			if(true || this.term != node.term) {
+			children += node
+			node
+		}
+		else
+			this
+	}
+	
+	/**
+	 * Attempts to add a node that is just a String label and doesn't actually contain an atom. 
+	 * This mainly used for the rewrite tree to self-document itself.
+	 * @param		label is the String the child node will have. 
+	 * @return		a new label node if successful. Otherwise returns this. 
+	 */
+	
+	def addChild(label : String) : RWTreeNode = {
+			if(true || this.term != label) {
+			val node = new RWTreeNode(label)
 			children += node
 			node
 		}

--- a/Elision/src/ornl/elision/core/SequenceMatcher.scala
+++ b/Elision/src/ornl/elision/core/SequenceMatcher.scala
@@ -73,16 +73,8 @@ object SequenceMatcher {
       Fail("Sequences are not the same length.")
     else _tryMatch(patterns, subjects, binds, 0)
   }
-        
-  /**
-   * Rewrite a sequence of atoms by applying the given bindings to each.
-   * 
-   * @param subjects	The atoms to rewrite.
-   * @param binds			The bindings to apply.
-   * @return	A pair consisting of the rewritten sequence of atoms and a flag
-   * 					that is true if any rewrites succeeded.
-   */
-  def rewrite(subjects: OmitSeq[BasicAtom], binds: Bindings) = {
+   /*
+   def rewrite(subjects: OmitSeq[BasicAtom], binds: Bindings) = {
     var changed = false
     def doit(atoms: IndexedSeq[BasicAtom]): IndexedSeq[BasicAtom] =
       if (atoms.isEmpty) IndexedSeq[BasicAtom]() else {
@@ -92,6 +84,36 @@ object SequenceMatcher {
       }
     (doit(subjects), changed)
   }
+   */
+	//////////////////// GUI changes
+  /**
+   * Rewrite a sequence of atoms by applying the given bindings to each.
+   * 
+   * @param subjects	The atoms to rewrite.
+   * @param binds			The bindings to apply.
+   * @return	A pair consisting of the rewritten sequence of atoms and a flag
+   * 					that is true if any rewrites succeeded.
+   */
+  def rewrite(subjects: OmitSeq[BasicAtom], binds: Bindings) = {
+	// get the node representing this atom that is being rewritten
+	val rwNode = RWTree.current.addChild("object SequenceMatcher rewrite: ")
+	val seqNode = rwNode.addChild("sequence: ")
+	
+    var changed = false
+    def doit(atoms: IndexedSeq[BasicAtom]): IndexedSeq[BasicAtom] =
+      if (atoms.isEmpty) IndexedSeq[BasicAtom]() else {
+		val headNode = seqNode.addChild(atoms.head)
+		RWTree.current = headNode
+        
+		val (newatom, change) = atoms.head.rewrite(binds)
+		headNode.addChild(newatom)
+		
+        changed |= change
+        newatom +: doit(atoms.tail)
+      }
+    (doit(subjects), changed)
+  }
+  //////////////////// end GUI changes
 
   /**
    * Match two sequences of atoms, in order.

--- a/Elision/src/ornl/elision/core/SpecialForm.scala
+++ b/Elision/src/ornl/elision/core/SpecialForm.scala
@@ -277,13 +277,31 @@ extends BasicAtom {
       }
     case _ => Fail("Special forms match only special forms.", this, subject)
   }
-
+	
+	//////////////////// GUI changes
   def rewrite(binds: Bindings) = {
+	// get the node representing this atom that is being rewritten
+	val rwNode = RWTree.current.addChild("SpecialForm rewrite: ")
+	val tagNode = rwNode.addChild("Tag: ").addChild(tag)
+	val contentNode = rwNode.addChild("Content: ").addChild(content)
+	
+	RWTree.current = tagNode
     val newtag = tag.rewrite(binds)
+	tagNode.addChild(newtag._1)
+	
+	RWTree.current = contentNode
     val newcontent = content.rewrite(binds)
-    if (newtag._2 || newcontent._2) (SpecialForm(newtag._1, newcontent._1), true)
+	contentNode.addChild(newcontent._1)
+	
+    if (newtag._2 || newcontent._2) {
+		RWTree.current = rwNode
+		val newSF = SpecialForm(newtag._1, newcontent._1)
+		rwNode.addChild(newSF)
+		(newSF, true)
+	}
     else (this, false)
   }
+	//////////////////// end GUI changes
   
   override def toString = "SpecialForm(" + tag + ", " + content + ")"
 

--- a/Elision/src/ornl/elision/core/Variable.scala
+++ b/Elision/src/ornl/elision/core/Variable.scala
@@ -138,7 +138,9 @@ class Variable(typ: BasicAtom, val name: String,
       // variable of the same name and type, and having chaos ensue.
       Fail("Variable is not bindable.", this, subject)
 
-  def rewrite(binds: Bindings) = {
+	  
+	/*
+	def rewrite(binds: Bindings) = {
     // If this variable is bound in the provided bindings, replace it with the
     // bound value.
     binds.get(name) match {
@@ -153,6 +155,36 @@ class Variable(typ: BasicAtom, val name: String,
         }
     }
   }
+  */
+	  //////////////////// GUI changes
+  def rewrite(binds: Bindings) = {
+	// get the node representing this atom that is being rewritten
+	val rwNode = RWTree.current.addChild("Variable rewrite: ")
+	val typeNode = rwNode.addChild(theType)
+	
+    // If this variable is bound in the provided bindings, replace it with the
+    // bound value.
+    binds.get(name) match {
+      case Some(atom) =>
+        rwNode.addChild(atom)
+		(atom, true)
+      case None =>
+		RWTree.current = typeNode
+        // While the atom is not bound, its type might have to be rewritten.
+        theType.rewrite(binds) match {
+          case (newtype, changed) =>
+			typeNode.addChild(newtype)
+            if (changed) { 
+				RWTree.current = rwNode
+				val newVar = Variable(newtype, name)
+				rwNode.addChild(newVar)
+				(newVar, true) 
+			} else (this, false)
+          case _ => (this, false)
+        }
+    }
+  }
+  //////////////////// end GUI changes
 
   def toParseString = prefix + toESymbol(name) +
   		(if (guard != Literal.TRUE) "{" + guard.toParseString + "}" else "") +

--- a/Elision/src/sage2D/Camera.scala
+++ b/Elision/src/sage2D/Camera.scala
@@ -57,6 +57,11 @@ class Camera(var x : Double = 0, var y : Double = 0, var pWidth : Double, var pH
 	/** The current y-position of the camera's focal center in screen coordinates. By default, this is set to the center of the parent panel. */
 	var cy : Double = pHeight/2
 	
+	var xLeftEdge : Double = 0.0
+	var xRightEdge : Double = pWidth
+	var yTopEdge : Double = 0.0
+	var yBottomEdge : Double = pHeight
+	
 	private var transform : AffineTransform = new AffineTransform
 	private var inverse : AffineTransform = new AffineTransform
 	
@@ -90,6 +95,15 @@ class Camera(var x : Double = 0, var y : Double = 0, var pWidth : Double, var pH
 		transform.translate(0-x, 0-y)
 		
 		inverse = transform.createInverse
+		
+		// compute the world coordinates of the parent panel's edges
+		val upperLeft = inverse.transform(new Point2D.Double(0,0),null)
+		val lowerRight = inverse.transform(new Point2D.Double(pWidth,pHeight),null)
+		
+		xLeftEdge = upperLeft.getX
+		xRightEdge = lowerRight.getX
+		yTopEdge = upperLeft.getY
+		yBottomEdge = lowerRight.getY
 	}
 	
 	/**


### PR DESCRIPTION
The classes and objects in ornl/elision/core now have the code needed for constructing the rewrite tree for the GUI to visualize. So the GUI is now able to produce useful visualizations from Elision input. 

I've also added some modifications to the GUI code. There is now some color-coding in the tree visualization so that the user can tell apart nodes that actually represent Elision atoms from nodes used to self-document the tree structure. I've also made some changes to boost rendering performance, especially for large tree visualizations.
