### PR TITLE
Updated LyX document to use VERSION

### DIFF
--- a/Elision/doc/elision.lyx
+++ b/Elision/doc/elision.lyx
@@ -90,7 +90,7 @@ Elision User Guide
 \end_layout
 
 \begin_layout Dedicatory
-Version @VERSION@ Build @DSTAMP@@TSTAMP@
+Version @VERSION@ Build @VERSION@
 \end_layout
 
 \begin_layout Standard


### PR DESCRIPTION
Now the LyX document uses VERSION instead of the date and time stamp variables.
