### PR TITLE
Eva node limit, Eva ignores unfruitful rule rewrites

### DIFF
--- a/Elision/src/ornl/elision/core/RewriteRule.scala
+++ b/Elision/src/ornl/elision/core/RewriteRule.scala
@@ -506,12 +506,19 @@ class RewriteRule private (
     // Try to apply the rewrite rule.  Whatever we get back is the result.
     //println("Rewriting with rule.")
 	ReplActor ! ("Eva","pushTable","RewriteRule doRewrite")
+    ReplActor ! ("Eva", "saveNodeCount", "RewriteRule doRewrite")
     // top node of this subtree
 	ReplActor ! ("Eva", "addToSubroot", ("rwNode", "RewriteRule doRewrite: ")) // val rwNode = RWTree.addToCurrent("RewriteRule doRewrite: ")
 	ReplActor ! ("Eva", "addTo", ("rwNode", "atom", atom)) // val atomNode = RWTree.addTo(rwNode, atom)
 	ReplActor ! ("Eva", "setSubroot", "atom") // RWTree.current = atomNode
     val rwResult = _tryRewrite(atom, binds, hint)
-	ReplActor ! ("Eva", "addTo", ("atom", "", rwResult._1)) // RWTree.addTo(atomNode, rwResult._1)
+	
+    if(rwResult._2) {
+        ReplActor ! ("Eva", "addTo", ("atom", "", rwResult._1)) // RWTree.addTo(atomNode, rwResult._1)
+    }
+    else ReplActor ! ("Eva", "remLastChild", "subroot")
+    
+    ReplActor ! ("Eva", "restoreNodeCount", !rwResult._2)
     ReplActor ! ("Eva", "popTable", "RewriteRule doRewrite")
 	rwResult
   }

--- a/Elision/src/ornl/elision/core/RuleLibrary.scala
+++ b/Elision/src/ornl/elision/core/RuleLibrary.scala
@@ -237,134 +237,7 @@ extends Fickle with Mutable {
   }
   */
   
-	//////////////////// GUI changes
-//  /**
-//   * Rewrite the provided atom once, if possible.  Children may be rewritten,
-//   * depending on whether descent is enabled.
-//   * 
-//   * @param atom	The atom to rewrite.
-//   * @return	The rewritten atom, and true iff any rules were successfully
-//   * 					applied.
-//   */
-//   
-//  def rewriteOnce(atom: BasicAtom): (BasicAtom, Boolean) = {
-//	// get the node representing this atom that is being rewritten
-//	val rwNode = RWTree.current // it should still be atom from doRewrite
-//	
-//    var (newtop, appliedtop) = rewriteTop(atom)
-//	val topNode = rwNode.addChild(newtop)
-//	RWTree.current = topNode
-//	
-//    if (_descend) {
-//	    var (newatom, applied) = rewriteChildren(newtop)
-//	    rwNode.addChild(newatom)
-//		(newatom, appliedtop || applied)
-//    } else {
-//      (newtop, appliedtop)
-//    }
-//  }
-//  //////////////////// end GUI changes
-//  
-//  /**
-//   * Rewrite the atom at the top level, once.
-//   * 
-//   * @param atom	The atom to rewrite.
-//   * @return	The rewritten atom, and true iff any rules were successfully
-//   * 					applied.
-//   */
-//  def rewriteTop(atom: BasicAtom): (BasicAtom, Boolean) = {
-//	// get the node representing this atom that is being rewritten
-//	val rwNode = RWTree.current // it should still be newTop from rewriteOnce
-//	
-//    // Get the rules.
-//    val rules = getRules(atom)
-//	val rulesNode = rwNode.addChild("rules: ")
-//	
-//	if(rules.isEmpty)	rulesNode.addChild("Empty")
-//	
-//    // Now try every rule until one applies.
-//    for (rule <- rules) {
-//		val ruleNode = rulesNode.addChild(rule)
-//		RWTree.current = ruleNode
-//      val (newatom, applied) = rule.doRewrite(atom)
-//	  ruleNode.addChild(newatom)
-//      if (applied) {
-//			rwNode.addChild(newatom)
-//			return (newatom, applied)
-//		}
-//    }
-//    return (atom, false)
-//  }
-//  
-//  //////////////////// GUI changes
-//  /**
-//   * Recursively rewrite the atom and its children.
-//   * 
-//   * @param atom	The atom to rewrite.
-//   * @return	The rewritten atom, and true iff any rules were successfully
-//   * 					applied.
-//   */
-//  def rewriteChildren(atom: BasicAtom): (BasicAtom, Boolean) = {
-//		// get the node representing this atom that is being rewritten
-//		val rwNode = RWTree.current // it should still be newTop from rewriteOnce
-//		val childrenNode = rwNode.addChild("Children: ")
-//		RWTree.current = childrenNode
-//		
-//		atom match {
-//		  case AtomSeq(props, atoms) =>
-//			var flag = false
-//			val newAtoms = atoms.map { 
-//				atom =>
-//					val childatomNode = childrenNode.addChild(atom)
-//					RWTree.current = childatomNode
-//				  val (newatom, applied) = rewriteOnce(atom)
-//					childatomNode.addChild(newatom)
-//				  flag ||= applied
-//				  newatom
-//			}
-//			RWTree.current = childrenNode
-//			val newAS = AtomSeq(props, newAtoms)
-//			rwNode.addChild(newAS)
-//			(newAS, flag)
-//		  case Apply(op, AtomSeq(props, atoms)) =>
-//			var flag = false
-//			
-//			val newAtoms = atoms.map { 
-//				atom =>
-//					val childatomNode = childrenNode.addChild(atom)
-//					RWTree.current = childatomNode
-//				  val (newatom, applied) = rewriteOnce(atom)
-//					childatomNode.addChild(newatom)
-//				  flag ||= applied
-//				  newatom
-//			}
-//			
-//			RWTree.current = childrenNode
-//			val newAS = AtomSeq(props, newAtoms)
-//			
-//			RWTree.current = childrenNode
-//			val newApply = Apply(op, newAS)
-//			
-//			rwNode.addChild(newApply).addChild(newAS)
-//			(newApply, flag)
-//		  case Apply(lhs, rhs) =>
-//			val leftNode = childrenNode.addChild("left: ").addChild(lhs)
-//			RWTree.current = leftNode
-//			val newlhs = rewriteOnce(lhs)
-//			
-//			val rightNode = childrenNode.addChild("right: ").addChild(rhs)
-//			RWTree.current = rightNode
-//			val newrhs = rewriteOnce(rhs)
-//			
-//			val newApply = Apply(newlhs._1, newrhs._1)
-//			rwNode.addChild(newApply)
-//			(newApply, newlhs._2 || newrhs._2)
-//		  case _ =>
-//			// Do nothing in this case.
-//			(atom, false)
-//	  }
-//  }
-//  //////////////////// end GUI changes
+
   
   /**
    * Rewrite the provided atom once, if possible.  Children may be rewritten,
@@ -488,7 +361,7 @@ extends Fickle with Mutable {
     if(ReplActor.disableRuleLibraryVis) ReplActor.disableGUIComs = true
     val (newatom, flag) = doRewrite(atom, Set.empty)
     ReplActor.disableGUIComs = tempDisabled
-    ReplActor ! ("Eva", "addTo", ("rwNode", "", newatom)) // RWTree.addTo(rwNode,newatom)
+    if(flag) ReplActor ! ("Eva", "addTo", ("rwNode", "", newatom)) // RWTree.addTo(rwNode,newatom)
     
     ReplActor ! ("Eva", "popTable", "RuleLibrary rewrite")
     (newatom, flag)
@@ -523,36 +396,6 @@ extends Fickle with Mutable {
     (newatom, flag)
   }
   //////////////////// end GUI changes
-
-//	//////////////////// GUI changes
-//  /**
-//   * Rewrite the given atom, repeatedly applying the rules of the active
-//   * rulesets.  This is limited by the rewrite limit.
-//   * 
-//   * @param atom	The atom to rewrite.
-//   * @param bool	Flag used for tracking whether any rules have succeeded.
-//   * @param limit	The remaining rewrite limit.
-//   */
-//  private def doRewrite(atom: BasicAtom, bool: Boolean = false,
-//      limit: BigInt = _limit): (BasicAtom, Boolean) = {
-//	// get the node representing this atom that is being rewritten
-//	val rwNode = RWTree.current.addChild("RuleLibrary doRewrite: ")
-//	val atomNode = rwNode.addChild(atom)
-//	RWTree.current = atomNode
-//	  
-//    if (limit <= 0) return (atom, bool)
-//    else rewriteOnce(atom) match {
-//      case (newatom, false) =>
-//		atomNode.addChild(newatom)
-//        (newatom, bool)
-//      case (newatom, true) =>
-//		atomNode.addChild(newatom)
-//        val result = doRewrite(newatom, true, limit-1)
-//		atomNode.addChild(result._1)
-//		result
-//    }
-//  }
-//  //////////////////// end GUI changes
 
   /**
    * Rewrite the given atom, repeatedly applying the rules of the active

--- a/Elision/src/ornl/elision/gui/ConsolePanel.scala
+++ b/Elision/src/ornl/elision/gui/ConsolePanel.scala
@@ -226,7 +226,7 @@ class EditorPaneOutputStream( var textArea : EditorPane, var maxLines : Int, val
 					result += """</font>"""
 					fontStartCount -= 1
 				}
-				result += """..."""
+				result += """...<br/>"""
 				return result
 			}
 			

--- a/Elision/src/ornl/elision/gui/EvaConfig.scala
+++ b/Elision/src/ornl/elision/gui/EvaConfig.scala
@@ -58,6 +58,9 @@ class EvaConfig extends Serializable {
     
     /** Flag for disabling syntax coloring in NodeSprites. */
     var disableNodeSyntaxColoring = false
+    
+    /** The maximum nodes that Eva will include in a tree visualization. */
+    var nodeLimit = 10000
 	
 	// try to read config information from Eva's config file (if it exists)
 	try {
@@ -72,6 +75,7 @@ class EvaConfig extends Serializable {
                     maxTreeDepth = (config \ "maxTreeDepth").text.toInt
                     disableTree = (config \ "disableTree").text.toBoolean
                     disableNodeSyntaxColoring = (config \ "disableNodeSyntaxColoring").text.toBoolean
+                    nodeLimit = (config \ "nodeLimit").text.toInt
                 } catch { case _ => System.err.println("One or more configurations didn't load from EvaConfig, \nprobably because you just updated to a newer version of Eva with new shiny features.")}
 			case _ => restoreDefaults
 		}
@@ -88,6 +92,7 @@ class EvaConfig extends Serializable {
         maxTreeDepth = -1
         disableTree = false
         disableNodeSyntaxColoring = false
+        nodeLimit = 10000
 	}
 	
 	/** Saves the configuration object to ".\EvaConfig.xml" */
@@ -103,6 +108,7 @@ class EvaConfig extends Serializable {
     <maxTreeDepth>""" + maxTreeDepth + """</maxTreeDepth>
     <disableTree>""" + disableTree + """</disableTree>
     <disableNodeSyntaxColoring>""" + disableNodeSyntaxColoring + """</disableNodeSyntaxColoring>
+    <nodeLimit>""" + nodeLimit + """</nodeLimit>
 </Eva>
 """
 

--- a/Elision/src/ornl/elision/gui/TreeBuilder.scala
+++ b/Elision/src/ornl/elision/gui/TreeBuilder.scala
@@ -67,6 +67,12 @@ class TreeBuilder extends Thread {
     /** A reference for the TreeBuilder's actor. All operations with the TreeBuilder should be done through this actor to ensure concurrency. */
     val tbActor = new TreeBuilderActor(this)
     
+    /** A count of the nodes currently in the tree. */
+    var nodeCount = 0
+    
+    /** Used by saveNodeCount and restoreNodeCount allow removal of subtrees while maintaining the correct nodeCount for this tree. */
+    val savedNodeCount = new ArrayStack[Int]
+    
     /** Clears the TreeBuilder's members. */
     def clear : Unit = {
         root = null
@@ -74,6 +80,8 @@ class TreeBuilder extends Thread {
         curScope = null
         scopeStack.clear()
         fatalError = false
+        nodeCount = 0
+        savedNodeCount.clear()
     }
     
     /** 
@@ -91,6 +99,8 @@ class TreeBuilder extends Thread {
         curScope += ("root" -> root)
         curScope += ("subroot" -> root)
         setSubroot("root")
+        nodeCount = 1
+        
     }
     
     /**
@@ -296,13 +306,49 @@ class TreeBuilder extends Thread {
     
     
     
+    /**
+     * Removes the last child of a NodeSprite
+     * @param parentID      The id key for the parent node we are removing the last child from.
+     */
+     def remLastChild(parentID : String) : Unit = {
+        if(fatalError) return
+        
+        var keepgoing = true
+        while(keepgoing) {
+            try {
+                val parent = curScope(parentID)
+                parent.remLastChild
+                keepgoing = false
+            } 
+            catch {
+                case _ => System.err.println("TreeBuilder.remLastChild error: key \"" + parentID + "\" does not exist in current scope table.")
+                    keepgoing = attemptStackRecovery
+            }
+        }
+     }
     
+    /**
+     * Saves the current node count.
+     */
+    def saveNodeCount : Unit = {
+        savedNodeCount.push(nodeCount)
+    }
+    
+    /**
+     * Sets the current node count to the top value of savedNodeCount. This is useful for restoring the correct node count for the tree when a subtree is removed.
+     */
+    def restoreNodeCount(flag : Boolean) : Unit = {
+        if(flag) nodeCount = savedNodeCount.pop
+        else savedNodeCount.pop
+    }
     
     
     /** Helper method used to create a comment NodeSprite */
     private def createCommentNode(commentAtom : String, parent : NodeSprite) : NodeSprite = {
         val node = new NodeSprite(commentAtom, parent, true)
         parent.addChild(node)
+        nodeCount += 1
+        enforceNodeLimit
         node
     }
     
@@ -333,6 +379,8 @@ class TreeBuilder extends Thread {
 		}
         
         if(parent != null) parent.addChild(node)
+        nodeCount += 1
+        enforceNodeLimit
         node
     }
     
@@ -367,15 +415,31 @@ class TreeBuilder extends Thread {
     }
     
     
+    /** Enforces the node limit by causing a fatal error when we've reached our node limit. */
+    private def enforceNodeLimit : Boolean = {
+        if(nodeCount >= mainGUI.config.nodeLimit && mainGUI.config.nodeLimit > 1) {
+            val node = new NodeSprite("Eva tree node limit " + mainGUI.config.nodeLimit + " has been reached! Halting further tree construction. " , root, true)
+            System.err.println("Fatal error during TreeBuilder tree construction. \n\tEva tree node limit " + mainGUI.config.nodeLimit + " has been reached!")
+            root.addChild(node)
+            val node2 = new NodeSprite("Eva tree node limit " + mainGUI.config.nodeLimit + " has been reached! Halting further tree construction. " , root, true)
+            subroot.addChild(node2)
+            fatalError = true
+            true
+        }
+        false
+    }
+    
     
     /** Starts a new thread in which the TreeBuilder will run in. */
 	override def run : Unit = {
 		tbActor.start
         
+        fatalError
         while(true) {}
 	}
     
 }
+
 
 
 /** An actor object for doing concurrent operations with a TreeBuilder. */
@@ -440,6 +504,21 @@ class TreeBuilderActor(val treeBuilder : TreeBuilder) extends Actor {
                         treeBuilder.addTo(parentID, id, atom)
                     case _ => System.err.println("TreeBuilder.addTo received incorrect arguments: " + args)
                 }
+            case "remLastChild" =>
+                args match {
+                    case parentID : String =>
+                        treeBuilder.remLastChild(parentID)
+                    case _ => System.err.println("TreeBuilder.remLastChild received incorrect arguments: " + args)
+                }
+            case "saveNodeCount" => 
+                treeBuilder.saveNodeCount
+            case "restoreNodeCount" =>
+                args match {
+                    case flag : Boolean =>
+                        treeBuilder.restoreNodeCount(flag)
+                    case _ => System.err.println("TreeBuilder.restoreNodeCount received incorrect arguments: " + args)
+                }
+                
             case _ => System.err.println("GUIActor received bad TreeBuilder command: " + cmd)
         }
     }

--- a/Elision/src/ornl/elision/gui/TreeSprite.scala
+++ b/Elision/src/ornl/elision/gui/TreeSprite.scala
@@ -670,6 +670,13 @@ class NodeSprite(var term : String = "Unnamed Node", val parent : NodeSprite = n
 		children += node
 	}
 	
+    
+    /** Removes the last child of this NodeSprite. */
+    def remLastChild : Boolean = {
+        if(children.size == 0) return false
+        children.remove(children.size - 1)
+        true
+    }
 	
 	/**
 	 * Obtains the position of a child node relative to this node.

--- a/Elision/src/ornl/elision/gui/mainGUI.scala
+++ b/Elision/src/ornl/elision/gui/mainGUI.scala
@@ -195,6 +195,14 @@ class GuiMenuBar extends MenuBar {
         }
 		disableNodeColoringItem.mnemonic = event.Key.N
 		viewMenu.contents += disableNodeColoringItem
+        
+        // Set Node Limit : 
+        
+        val setNodeLimitItem = new MenuItem(Action("Set Node Limit") {
+			val dia = new NodeLimitDialog
+		} )
+		setNodeLimitItem.mnemonic = event.Key.O
+		viewMenu.contents += setNodeLimitItem
 	
 	// Help menu	
 		
@@ -345,7 +353,6 @@ class GuiMenuBar extends MenuBar {
 		
 		contents = new BorderPanel {
 			border = new javax.swing.border.EmptyBorder(inset,inset,inset,inset)
-			val minLines = ConsolePanel.infiniteMaxLines
 			layout( new GridPanel(2,1) { 
 						contents += new Label("Enter max depth: (integer)")
 						contents += new Label("(< 0 will make there be no depth limit)") 
@@ -360,7 +367,7 @@ class GuiMenuBar extends MenuBar {
 		
 		/** 
 		 * processes the input for the dialog when the user clicks OK or presses Enter 
-		 * @param input		The input string being evaluated as the new value for the REPL's maximum lines.
+		 * @param input		The input string being evaluated as the new value for the maximum tree depth.
 		 */
 		private def enterInput(input : String) : Unit = {
 			// if the input is an integer > 0, proceed to set the decompression depth to the input. 
@@ -370,6 +377,57 @@ class GuiMenuBar extends MenuBar {
 				val fieldInt = input.toInt
 				GUIActor.treeBuilder.treeMaxDepth = fieldInt
 				mainGUI.config.maxTreeDepth = fieldInt
+				mainGUI.config.save
+				// close the dialog when we finish processing input
+				close
+			} catch {
+				case _ =>
+			}
+		}
+		
+		// open the dialog when it is finished setting up
+		open
+	}
+    
+    
+    
+    
+    /** The dialog window for the "View > Set Node Limit" menu item */
+	class NodeLimitDialog extends Dialog {
+		this.title = "Set Node Limit"
+		val inset = 3
+		border = new javax.swing.border.EmptyBorder(inset,inset,inset,inset)
+		
+		val linesInput = new TextField(10) { 
+			listenTo(keys) 
+			reactions += { case e : swing.event.KeyTyped => if(e.char == '\n') enterInput(text) }
+			text = "" + mainGUI.config.nodeLimit
+		}
+		val okBtn = new Button(Action("OK") {enterInput(linesInput.text)})
+		val cancelBtn = new Button(Action("Cancel") { close } )
+		
+		contents = new BorderPanel {
+			border = new javax.swing.border.EmptyBorder(inset,inset,inset,inset)
+			layout( new GridPanel(2,1) { 
+						contents += new Label("Enter node limit: (integer)")
+						contents += new Label("(< 2 will make there be no node limit)") 
+					} ) = North
+			layout(linesInput) = Center
+			layout(new FlowPanel {
+				contents += okBtn
+				contents += cancelBtn
+			} ) = South
+		}
+		
+		
+		/** 
+		 * processes the input for the dialog when the user clicks OK or presses Enter 
+		 * @param input		The input string being evaluated as the new value for the node limit.
+		 */
+		private def enterInput(input : String) : Unit = {
+			try {
+				val fieldInt = input.toInt
+				mainGUI.config.nodeLimit = fieldInt
 				mainGUI.config.save
 				// close the dialog when we finish processing input
 				close


### PR DESCRIPTION
Users can now set a limit to the number of nodes created in an Eva tree. When this limit is reached, Elision will keep processing as normal, but Eva will discard all further TreeBuilder messages until Elision has finished processing its current input. 

Also, Eva will no longer create nodes for RewriteRules that don't result in any rewrites. 
