### PR TITLE
Bootstrap fail updates, updated web page in config.xml

### DIFF
--- a/Elision/etc/config.xml
+++ b/Elision/etc/config.xml
@@ -39,7 +39,7 @@
 <configuration
 	name="Elision"
 	maintainer="Stacy Prowell (sprowell@gmail.com)"
-	web="http://stacyprowell.com/elision/">
+	web="http://elision.github.com/">
 	<!-- Build information.  The build attribute is filled in by the build
 		 process; do not modify it here. -->
 	<version

--- a/Elision/src/ornl/elision/repl/ERepl.scala
+++ b/Elision/src/ornl/elision/repl/ERepl.scala
@@ -355,11 +355,13 @@ class ERepl extends Processor {
     if (!read("bootstrap/Boot.eli", false)) {
       // Failed to find bootstrap file.  Stop.
       console.error("Unable to load bootstrap/Boot.eli.  Cannot continue.")
+      ReplActor ! ":quit"
       return
     }
     console.quiet = 0
     if (console.errors > 0) {
       console.error("Errors were detected during bootstrap.  Cannot continue.")
+      ReplActor ! ":quit"
       return
     }
     
@@ -371,6 +373,7 @@ class ERepl extends Processor {
       if (console.errors > 0) {
         console.error("Errors were detected processing " + _rc +
             ".  Cannot continue.")
+        ReplActor ! ":quit"
         return
       }
     }
@@ -470,7 +473,6 @@ class ERepl extends Processor {
       // Watch for the end of stream or the special :quit token.
       if (segment == null || (line.trim.equalsIgnoreCase(":quit"))) {
 		//////////////////// GUI changes
-		if(ReplActor.guiMode)  ReplActor.guiActor ! "quit"
         ReplActor ! ":quit"
 		//////////////////// end GUI changes
         return

--- a/Elision/src/ornl/elision/repl/ReplActor.scala
+++ b/Elision/src/ornl/elision/repl/ReplActor.scala
@@ -76,6 +76,7 @@ object ReplActor extends Actor {
                 case ("disableGUIComs", flag : Boolean) =>
                     disableGUIComs = flag
                 case ":quit" =>
+                    if(guiMode)  guiActor ! "quit"
                     exit
 				case str : String =>
 					guiInput = str


### PR DESCRIPTION
I modified the bootstrap fail return blocks to command the ReplActor to exit its thread before the Repl returns. 

The web address in config.xml has been updated to the new Elision home page url.
