### PR TITLE
Help() displays where operators are defined.

### DIFF
--- a/Elision/src/ornl/elision/core/Operator.scala
+++ b/Elision/src/ornl/elision/core/Operator.scala
@@ -173,6 +173,11 @@ object Operator {
     case so: SymbolicOperator => Some((so.name, so.theType, so.params))
     case co: CaseOperator => Some((co.name, co.theType, co.cases))
   }
+  
+  /**
+   * Creates a string to append to an operator's detail for informing the user in what file this operator was declared.
+   */
+   def declaredInString : String = "\n \nDeclared in: " + ornl.elision.parse.Processor.fileReadStack.top
 }
 
 /**
@@ -281,7 +286,7 @@ object CaseOperator {
     val typ = bh.fetchAs[BasicAtom]("type", Some(ANY))
     var description = bh.fetchAs[StringLiteral]("description", Some("No description."))
     if (description.value(0) == '|') description = description.value.stripMargin('|')
-    val detail = bh.fetchAs[StringLiteral]("detail", Some("No detail."))
+    val detail = bh.fetchAs[StringLiteral]("detail", Some("No detail.")) + Operator.declaredInString
     val evenMeta = bh.fetchAs[BooleanLiteral]("evenmeta", Some(false)).value
     return new CaseOperator(sfh, name, typ, cases, description, detail, evenMeta)
   }
@@ -305,7 +310,7 @@ object CaseOperator {
     val nameS = Literal(Symbol(name))
     val binds = Bindings() + ("name" -> nameS) + ("cases" -> cases) +
       ("type" -> typ) + ("description" -> Literal(description)) +
-      ("detail" -> Literal(detail))
+      ("detail" -> Literal(detail + Operator.declaredInString))     // Cazra TODO: add in declaring file's name into the detail string.
     val sfh = new SpecialFormHolder(Operator.tag, binds)
     return new CaseOperator(sfh, name, typ, cases, description, detail, evenMeta)
   }
@@ -458,7 +463,7 @@ object TypedSymbolicOperator {
     var description = bh.fetchAs[StringLiteral]("description", Some("No description."))
     if (description.length > 0 && description.value(0) == '|')
       description = description.value.stripMargin('|')
-    val detail = bh.fetchAs[StringLiteral]("detail", Some("No detail."))
+    val detail = bh.fetchAs[StringLiteral]("detail", Some("No detail.")) + Operator.declaredInString    // Cazra TODO: add in declaring file's name into the detail string.
     val evenMeta = bh.fetchAs[BooleanLiteral]("evenmeta", Some(false)).value
 
     // Fetch the handler text.
@@ -527,12 +532,13 @@ object TypedSymbolicOperator {
    * @return	The typed symbolic operator.
    */
   def apply(name: String, typ: BasicAtom, params: AtomSeq,
-    description: String, detail: String,
+    description: String, ddetail: String,
     evenMeta: Boolean = false): TypedSymbolicOperator = {
+    val detail = ddetail + Operator.declaredInString
     val nameS = Literal(Symbol(name))
     val binds = Bindings() + ("name" -> nameS) + ("params" -> params) +
       ("type" -> typ) + ("description" -> Literal(description)) +
-      ("detail" -> Literal(detail)) + ("evenmeta" -> Literal(evenMeta))
+      ("detail" -> Literal(detail)) + ("evenmeta" -> Literal(evenMeta)) 
     val sfh = new SpecialFormHolder(Operator.tag, binds)
     return new TypedSymbolicOperator(sfh, name, typ, params,
       description, detail, evenMeta)
@@ -594,8 +600,9 @@ object SymbolicOperator {
    * @return	The typed symbolic operator.
    */
   def apply(name: String, typ: BasicAtom, params: AtomSeq,
-    description: String, detail: String,
+    description: String, ddetail: String,
     evenMeta: Boolean = false): SymbolicOperator = {
+    val detail = ddetail + Operator.declaredInString
     val nameS = Literal(Symbol(name))
     val binds = Bindings() + ("name" -> nameS) + ("params" -> params) +
       ("type" -> typ) + ("description" -> Literal(description)) +

--- a/Elision/src/ornl/elision/gui/ConsolePanel.scala
+++ b/Elision/src/ornl/elision/gui/ConsolePanel.scala
@@ -318,6 +318,7 @@ class EditorPaneOutputStream( var textArea : EditorPane, var maxLines : Int, val
 		
 		result = result.replaceAllLiterally(" ","""&nbsp;""")
 		result = result.replaceAllLiterally("\t","""&nbsp;&nbsp;&nbsp;""")
+     //   result = result.replaceAllLiterally("\n","""<BR/>""")
 		
 		result
 	}

--- a/Elision/src/ornl/elision/repl/ERepl.scala
+++ b/Elision/src/ornl/elision/repl/ERepl.scala
@@ -447,6 +447,8 @@ class ERepl extends Processor {
       // A little function to prompt for, and read, the next segment.  The
       // segment is accumulated into the line. 
       def fetchline(p1: String, p2: String): Boolean = {
+        Processor.fileReadStack.clear
+        Processor.fileReadStack.push("Console")
       	//////////////////// GUI changes
 		segment = 	if (ReplActor.guiMode) {  
                 println()


### PR DESCRIPTION
Operators now automatically include in their details the file where they are defined. This will show up when you call help() on an operator or anyplace else that displays an operator's details. Operators defined in the console will show "Console" for where they are defined in.
