### PR TITLE
Interactive Elision rule creation

### DIFF
--- a/Elision/src/ornl/elision/core/Apply.scala
+++ b/Elision/src/ornl/elision/core/Apply.scala
@@ -180,11 +180,28 @@ object Apply {
    */
   def apply(op: BasicAtom, arg: BasicAtom,
       bypass: Boolean = false): BasicAtom = {
+      /*
+    val applyString : String = { op match {
+                case opp : Operator => 
+                    toESymbol(opp.name)
+                case opref : OperatorRef =>
+                    toESymbol(opref.name)
+                case _ =>
+                    op.toParseString
+            }} + "(" + 
+            {arg match {
+                case argSeq : AtomSeq => 
+                    argSeq.atoms.mkParseString("" , ", ", "")
+                case _ => 
+                    arg.toParseString
+            }} + ")"
+    */
       
     //////////////////// GUI changes
     ReplActor ! ("Eva","pushTable", "object Apply apply")
     // top node of this subtree
     ReplActor ! ("Eva", "addToSubroot", ("rwNode", "object Apply apply: ")) // val rwNode = RWTree.addToCurrent("object Apply apply: ") 
+   // ReplActor ! ("Eva", "addTo", ("rwNode0", "rwNode", applyString))
     ReplActor ! ("Eva", "addTo", ("rwNode", "op", "Operator: ", op)) // val opNode = RWTree.addTo(rwNode, "Operator: ", op) 
     ReplActor ! ("Eva", "addTo", ("rwNode", "arg", "Argument: ", arg)) // val argNode = RWTree.addTo(rwNode, "Argument: ", arg) 
     ReplActor ! ("Eva", "setSubroot", "rwNode") // RWTree.current = rwNode
@@ -194,6 +211,7 @@ object Apply {
     // Do not try to compute if metaterms are present.
     if (!op.evenMeta && !arg.isTerm) {
         val result = SimpleApply(op, arg)
+        ReplActor ! ("Eva", "addTo", ("rwNode", "", result))
         ReplActor ! ("Eva", "popTable", "object Apply apply")
         result
     } else {
@@ -202,6 +220,7 @@ object Apply {
   		    // If the argument is also a string literal, then we want to simply
   		    // concatenate them.
   		    val result = StringLiteral(typ, str + arg.asInstanceOf[StringLiteral].value)
+            ReplActor ! ("Eva", "addTo", ("rwNode", "", result))
             ReplActor ! ("Eva", "popTable", "object Apply apply")
             result
   	    case app:Applicable =>
@@ -209,6 +228,7 @@ object Apply {
   		      // The lhs is applicable; invoke its apply method.  This will
   		      // return some atom, and that atom is the overall result.
   		      val result = app.doApply(arg, bypass)
+              ReplActor ! ("Eva", "addTo", ("rwNode", "", result))
               ReplActor ! ("Eva", "popTable", "object Apply apply")
               result
   	      } catch {
@@ -226,6 +246,7 @@ object Apply {
   	      val result = BindingsAtom(Bindings() +
   	          ("atom" -> r_atom) +
   	          ("flag" -> (if (r_flag) Literal.TRUE else Literal.FALSE)))
+          ReplActor ! ("Eva", "addTo", ("rwNode", "", result))
           ReplActor ! ("Eva", "popTable", "object Apply apply")
           result
   	    case _ =>
@@ -233,6 +254,7 @@ object Apply {
   	      // expression that we have yet to evaluate.  Just build a simple
   	      // apply of the lhs and rhs.
   	      val result = SimpleApply(op, arg)
+          ReplActor ! ("Eva", "addTo", ("rwNode", "", result))
           ReplActor ! ("Eva", "popTable", "object Apply apply")
           result
 	    }

--- a/Elision/src/ornl/elision/gui/ConsolePanel.scala
+++ b/Elision/src/ornl/elision/gui/ConsolePanel.scala
@@ -238,6 +238,13 @@ class EditorPaneOutputStream( var textArea : EditorPane, var maxLines : Int, val
     def act() = {
         loop {
             react {
+                case ("bumpCaret", true) =>
+                    try {
+                        textArea.caret.position = math.max(anchorPos, textArea.caret.position)
+                    }
+                    catch {
+                        case _ =>
+                    }
                 case _newTxt : String =>
                     try {
                         var newTxt = _newTxt
@@ -411,6 +418,7 @@ class EditorPaneInputStream( var taos : EditorPaneOutputStream) {
 					case _ => avoidInfLoop = true
 				}
 			}
+            
 			
 			// keyboard menu shortcuts
 			
@@ -418,6 +426,19 @@ class EditorPaneInputStream( var taos : EditorPaneOutputStream) {
 				mainGUI.guiMenuBar.openItem.doClick
             if(e.key == swing.event.Key.F1)
                 mainGUI.guiMenuBar.helpItem.doClick
+                
+            
+            mainGUI.visPanel match {
+                case etvp : elision.EliTreeVisPanel =>
+                    if(e.key == swing.event.Key.R && e.modifiers == swing.event.Key.Modifier.Control) {
+                        etvp.selectingRuleLHS = true
+                    }
+                    if(e.key == swing.event.Key.Escape) {
+                        etvp.selectingRuleLHS = false
+                    }
+                case _ =>
+            }
+            
 			
 		}
 		case e : swing.event.KeyReleased => {
@@ -437,6 +458,14 @@ class EditorPaneInputStream( var taos : EditorPaneOutputStream) {
 					case _ => {}
 				}
 			}
+            if(e.key == swing.event.Key.Home) {
+                var avoidInfLoop = false
+				try {
+					textArea.caret.position = math.max(taos.anchorPos, textArea.caret.position)
+				} catch {
+					case _ => avoidInfLoop = true
+				}
+            }
 			textArea.caret.visible = true
 		}
 		

--- a/Elision/src/ornl/elision/gui/GUIActor.scala
+++ b/Elision/src/ornl/elision/gui/GUIActor.scala
@@ -116,6 +116,8 @@ object GUIActor extends Actor {
                         treeBuilder.tbActor ! ("OpenTree", file)
                     case ("SaveTree", file : java.io.File) =>
                         treeBuilder.tbActor ! ("SaveTree", file)
+                    case "IgnoreNextTree" => 
+                        treeBuilder.tbActor ! "IgnoreNextTree"
                     case selFile : java.io.File => 
                         // The actor reacts to a File by passing the file's contents to the REPL to be processed as input.
                         if(!mainGUI.config.disableTree) mainGUI.visPanel.isLoading = true

--- a/Elision/src/ornl/elision/gui/elision/EliMenu.scala
+++ b/Elision/src/ornl/elision/gui/elision/EliMenu.scala
@@ -1,0 +1,152 @@
+/*======================================================================
+ *       _ _     _
+ *   ___| (_)___(_) ___  _ __
+ *  / _ \ | / __| |/ _ \| '_ \
+ * |  __/ | \__ \ | (_) | | | |
+ *  \___|_|_|___/_|\___/|_| |_|
+ * The Elision Term Rewriter
+ * 
+ * Copyright (c) 2012 by UT-Battelle, LLC.
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * Collection of administrative costs for redistribution of the source code or
+ * binary form is allowed. However, collection of a royalty or other fee in excess
+ * of good faith amount for cost recovery for such redistribution is prohibited.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER, THE DOE, OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+======================================================================*/
+
+package ornl.elision.gui.elision
+
+import ornl.elision.gui._
+import swing._
+import swing.BorderPanel.Position._
+
+/** The menu for Elision-mode-specific things. */
+object EliMenu {
+    // Elision menu	
+		
+	val eliMenu = new Menu("Elision")
+	eliMenu.mnemonic = event.Key.C
+        
+        // Create Rule from Node : Create a new rule from an Elision atom in an Eva tree.
+		
+		val makeRuleItem = new MenuItem(Action("Create Rule from Node     Ctrl+ R") {
+			mainGUI.visPanel match {
+                case etvp : EliTreeVisPanel => 
+                    etvp.selectingRuleLHS = true
+                case _ =>
+            }
+		} )
+		makeRuleItem.mnemonic = event.Key.R
+        eliMenu.contents += makeRuleItem
+
+}
+
+
+class RulePredDialog(val lhs : String) extends Dialog {
+    this.title = "Create Rule from Node"
+    val inset = 3
+    
+    val linesInput = new TextField(10) { 
+        listenTo(keys) 
+        reactions += { case e : swing.event.KeyTyped => if(e.char == '\n') enterInput(text) }
+        text = ""
+    }
+    val okBtn = new Button(Action("OK") {enterInput(linesInput.text)})
+    val cancelBtn = new Button(Action("Cancel") { close } )
+    
+    contents = new BorderPanel {
+        border = new javax.swing.border.EmptyBorder(inset,inset,inset,inset)
+        layout( new GridPanel(2,1) { 
+                    contents += new Label("Enter new rule right-hand-side:")
+                    contents += new Label(lhs + " -> ")
+                } ) = North
+        layout(linesInput) = Center
+        layout(new FlowPanel {
+            contents += okBtn
+            contents += cancelBtn
+        } ) = South
+    }
+    
+    
+    /** 
+     * processes the input for the dialog when the user clicks OK or presses Enter 
+     * @param input		The input string for the rule's RHS.
+     */
+    private def enterInput(input : String) : Unit = {
+        // if the input is an integer > 0, proceed to set the decompression depth to the input. 
+        // Otherwise, just close the dialog.
+        val rhs = input
+        
+        try {
+            val openDirectory = mainGUI.config.lastOpenPath
+            val fc = new FileChooser(new java.io.File(openDirectory))
+            fc.fileFilter = new EliFileFilter
+			val result = fc.showSaveDialog(null)
+			val selFile = fc.selectedFile
+			if(selFile != null && result == FileChooser.Result.Approve) {
+				mainGUI.config.lastOpenPath = selFile.getParent
+				mainGUI.config.save
+				
+                var filePath = selFile.getPath
+                if(!filePath.endsWith(".eli")) filePath += ".eli"
+                
+                // create the parse string for the new rule declaration.
+                var ruleDecl = """decl.{rule
+    """ + lhs + """
+    -> 
+    """ + rhs
+                if(!rhs.contains("#rulesets"))
+                    ruleDecl += """
+    
+    #rulesets DEFAULT"""
+                ruleDecl += """
+}
+"""
+                
+                // save the rule to the file.
+                val fw = new java.io.FileWriter(filePath)
+                fw.write(ruleDecl)
+                fw.close
+                
+                // declare the rule in our context.
+                GUIActor ! "IgnoreNextTree"
+                GUIActor ! ("ReplInput", ruleDecl)
+			}
+            // close the dialog when we finish processing input
+            close
+        } catch {
+            case _ =>
+        }
+    }
+    
+    // open the dialog when it is finished setting up
+    open
+}
+
+
+
+
+
+
+

--- a/Elision/src/ornl/elision/gui/elision/EliTreeVisPanel.scala
+++ b/Elision/src/ornl/elision/gui/elision/EliTreeVisPanel.scala
@@ -1,0 +1,100 @@
+/*======================================================================
+ *       _ _     _
+ *   ___| (_)___(_) ___  _ __
+ *  / _ \ | / __| |/ _ \| '_ \
+ * |  __/ | \__ \ | (_) | | | |
+ *  \___|_|_|___/_|\___/|_| |_|
+ * The Elision Term Rewriter
+ * 
+ * Copyright (c) 2012 by UT-Battelle, LLC.
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * Collection of administrative costs for redistribution of the source code or
+ * binary form is allowed. However, collection of a royalty or other fee in excess
+ * of good faith amount for cost recovery for such redistribution is prohibited.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER, THE DOE, OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+======================================================================*/
+
+package ornl.elision.gui.elision
+
+import java.awt._
+import ornl.elision.gui._
+import ornl.elision.gui.trees._
+
+/** An extension of TreeVisPanel that handles some Elision-specific functions. */
+class EliTreeVisPanel extends TreeVisPanel {
+    var selectingRuleLHS = false
+    
+    override def timerLoop : Unit = {
+        super.timerLoop
+        
+        // keyboard input
+/*        // the escape key will cancel out of whatever interactive tool is being used.
+        if(keyboardIn.isPressed(swing.event.Key.Escape)) {
+            selectingRuleLHS = false
+        }
+        if(keyboardIn.justPressed(swing.event.Key.Home)) {
+            mainGUI.consolePanel.console.requestFocusInWindow
+            mainGUI.consolePanel.tos ! ("bumpCaret", true)
+        }
+        // CTRL + O is a shortcut for File > Open
+        if(keyboardIn.isPressed(swing.event.Key.Control) && keyboardIn.justPressed(swing.event.Key.O)) 
+            mainGUI.guiMenuBar.openItem.doClick
+        // CTRL + R is a shortcut for Elision > Create Rule from Node
+        if(keyboardIn.isPressed(swing.event.Key.Control) && keyboardIn.justPressed(swing.event.Key.R)) 
+            selectingRuleLHS = true
+        // F1 is a shortcut for Help > Help
+        if(keyboardIn.justPressed(swing.event.Key.F1)) 
+            mainGUI.guiMenuBar.helpItem.doClick
+            */
+        
+    }
+    
+    override def selectNode(clickedNode : NodeSprite) : Unit = {
+        super.selectNode(clickedNode)
+        
+        // Interactive rule creation: User selects an atom node for the LHS and then 
+        // inputs the RHS and saves it to an eli file.
+        if(clickedNode != null && selectingRuleLHS && !clickedNode.isComment) {
+            val ruleDia = new RulePredDialog(clickedNode.term)
+            selectingRuleLHS = false
+        }
+    }
+    
+    override def mainPaint(g : Graphics2D) : Unit = {
+        super.mainPaint(g)
+        
+        val helpPromptY = (this.size.getHeight-10).toInt
+        g.setColor(new Color(0x000000))
+        if(selectingRuleLHS) {
+            g.drawString("Create Rule from Node: Click a node representing an atom to be the left-hand-side of the rule. Press Esc to cancel.", 10,helpPromptY)
+        }
+    }
+}
+
+
+
+
+
+
+

--- a/Elision/src/ornl/elision/gui/mainGUI.scala
+++ b/Elision/src/ornl/elision/gui/mainGUI.scala
@@ -103,7 +103,7 @@ object mainGUI extends SimpleSwingApplication {
         mode match {
             case "Elision" => 
                 syntax.SyntaxFormatter.regexes = elision.EliRegexes
-                visPanel = new trees.TreeVisPanel
+                visPanel = new elision.EliTreeVisPanel
             case "Welcome" =>
                 syntax.SyntaxFormatter.regexes = null
                 visPanel = new welcome.WelcomePanel
@@ -266,6 +266,8 @@ class GuiMenuBar extends MenuBar {
                     viewMenu.contents += resetCameraItem
                 
                 this.contents += modeMenu
+                
+                this.contents += elision.EliMenu.eliMenu
                 
                 this.contents += ConsoleMenu.apply(mode)
                 

--- a/Elision/src/ornl/elision/gui/trees/TreeBuilder.scala
+++ b/Elision/src/ornl/elision/gui/trees/TreeBuilder.scala
@@ -625,7 +625,8 @@ class TreeBuilder extends Thread {
 
 /** An actor object for doing concurrent operations with a TreeBuilder. */
 class TreeBuilderActor(val treeBuilder : TreeBuilder) extends Actor {
-
+    var ignoreNextTree = false
+    
     def act() = {
 		loop {
 			receive {
@@ -675,6 +676,8 @@ class TreeBuilderActor(val treeBuilder : TreeBuilder) extends Actor {
                         else System.out.println("Failed to save the current tree.\n")
                     }
                     GUIActor ! "newPrompt"
+                case "IgnoreNextTree" =>
+                    ignoreNextTree = true
                 case cmd => System.err.println("Bad tree builder command: " + cmd)
             }
         }
@@ -697,16 +700,20 @@ class TreeBuilderActor(val treeBuilder : TreeBuilder) extends Actor {
                     case _ =>
                         null
                 }
-                if(treeVisPanel != null) {
-                    GUIActor ! ("loading", true)
+                
+                GUIActor ! ("loading", true)
+                if(treeVisPanel != null && !ignoreNextTree) {
+                    
                     treeVisPanel.treeSprite = treeBuilder.finishTree
                     
                     // once the tree visualization is built, select its root node and center the camera on it.
                     treeVisPanel.selectNode(treeVisPanel.treeSprite.root)
                     treeVisPanel.camera.reset
-                    GUIActor ! ("loading", false)
+                    
                 }
                 
+                ignoreNextTree = false
+                GUIActor ! ("loading", false)
                 
             case "pushTable" => 
                 treeBuilder.pushTable(args)

--- a/Elision/src/ornl/elision/gui/trees/TreeVisPanel.scala
+++ b/Elision/src/ornl/elision/gui/trees/TreeVisPanel.scala
@@ -69,6 +69,7 @@ class TreeVisPanel extends GamePanel with HasCamera {
 	
     /** The keyboard input interface for the panel */
 	val keyboardIn = new KeyboardInput(this)
+//    focusable = true
 	
 	/** Keeps track of the mouse's position in world coordinates */
 	var mouseWorldPosition : java.awt.geom.Point2D = new java.awt.geom.Point2D.Double(0,0)
@@ -221,7 +222,6 @@ class TreeVisPanel extends GamePanel with HasCamera {
 	 * It's mostly just processing mouse input for controlling the camera and selecting nodes.
 	 */
 	def timerLoop : Unit = {
-
 		keyboardIn.poll
 		
 		// handle mouse input.
@@ -229,6 +229,7 @@ class TreeVisPanel extends GamePanel with HasCamera {
 		mouseIn.poll
 		
 		if(mouseIn.justLeftPressed) {
+        //    requestFocusInWindow
 			val clickedNode = treeSprite.detectMouseOver(mouseWorldPosition)
 			selectNode(clickedNode)
 			camera.startDrag(mouseIn.position)


### PR DESCRIPTION
Eva now has a feature that allows you to create new rules in Eva by selecting a node representing an atom as the LHS. Then the user is prompted to provide the RHS for the rule and it is saved to an eli file with a save dialog. 

In Elision mode, this feature can be accessed from Elision>Create Rule from Node or with the keyboard shortcut Ctrl+ R. 
