### PR TITLE
crashinc option

### DIFF
--- a/Elision/src/bootstrap/Core.eli
+++ b/Elision/src/bootstrap/Core.eli
@@ -658,3 +658,21 @@ decl.{! fail()
        case _ => as_is
      }"""
 }
+
+decl.{! crashinc()
+  #handler=
+  """
+    exec match {
+      case p: ornl.elision.parse.Processor =>
+        p.crashRoot = !p.crashRoot
+        emitln("Crash at root is " + (if (p.crashRoot) "ON." else "OFF."))
+      case _ =>
+    }
+    _no_show
+  """
+  #description="Toggle whether to crash at the root upon error."
+  #detail=
+  "Enable or disable crashing execution at the root level when an error ".
+  "is encountered. This is ON by default. "
+}
+

--- a/Elision/src/ornl/elision/core/Memo.scala
+++ b/Elision/src/ornl/elision/core/Memo.scala
@@ -529,9 +529,10 @@ object Memo {
     val keyIterator = _cache.keySet.iterator
     while(keyIterator.hasNext) {
       val key = keyIterator.next
+      val value = _cacheCounter.get(key)
       
-      val count = if(_cacheCounter.containsKey(key)) {
-          _cacheCounter.get(key)
+      val count = if(value != null) {
+          value
         }
         else {
           0
@@ -569,8 +570,10 @@ object Memo {
     val keyIterator = _cache.keySet.iterator
     while(keyIterator.hasNext) {
       val key = keyIterator.next
-      val count = if(_cacheCounter.containsKey(key)) {
-          _cacheCounter.get(key)
+      val value = _cacheCounter.get(key)
+      
+      val count = if(value != null) {
+          value
         }
         else {
           0
@@ -632,9 +635,10 @@ object Memo {
     val keyIterator = _normal.keySet.iterator
     while(keyIterator.hasNext) {
       val key = keyIterator.next
+      val value = _normalCounter.get(key)
       
-      val count = if(_normalCounter.containsKey(key)) {
-          _normalCounter.get(key)
+      val count = if(value != null) {
+          value
         }
         else {
           0
@@ -671,9 +675,10 @@ object Memo {
     val keyIterator = _normal.keySet.iterator
     while(keyIterator.hasNext) {
       val key = keyIterator.next
+      val value = _normalCounter.get(key)
       
-      val count = if(_normalCounter.containsKey(key)) {
-          _normalCounter.get(key)
+      val count = if(value != null) {
+          value
         }
         else {
           0
@@ -702,8 +707,10 @@ object Memo {
   
   /** safely increments the counter for a key in _cacheCounter. */
   def _incCacheCounter(key : ((Int,BigInt),BitSet)) {
-    val curCount = if(_cacheCounter.containsKey(key)) {
-        _cacheCounter.get(key)
+    val value = _cacheCounter.get(key)
+    
+    val curCount = if(value != null) {
+        value
       }
       else {
         0
@@ -713,8 +720,10 @@ object Memo {
   
   /** safely increments the counter for a key in _normalCounter. */
   def _incNormalCounter(key : ((Int,BigInt),BitSet)) {
-    val curCount = if(_normalCounter.containsKey(key)) {
-        _normalCounter.get(key)
+    val value = _normalCounter.get(key)
+    
+    val curCount = if(value != null) {
+        value
       }
       else {
         0

--- a/Elision/src/ornl/elision/parse/Processor.scala
+++ b/Elision/src/ornl/elision/parse/Processor.scala
@@ -123,6 +123,9 @@ with HasHistory {
   /** Select the parser to use */
   private var _toggle = false
   
+  /** Whether to stop execution at the root level if an error occurs. */
+  private var _crashRoot = true
+  
   /** The queue of handlers, in order. */
   private var _queue = List[Processor.Handler]()
   
@@ -322,7 +325,14 @@ with HasHistory {
     	}
     } catch {
       case ElisionException(msg) =>
-        console.error(msg)
+        if(_crashRoot) {
+          // An error is encountered and execution of the root operation must stop.
+          throw new ElisionException(msg)
+        }
+        else {
+          // An error is encountered, but we only skip the rest of execution at this level.
+          console.error(msg)
+        }
       case ex: Exception =>
         console.error("(" + ex.getClass + ") " + ex.getMessage())
         val trace = ex.getStackTrace()
@@ -416,6 +426,16 @@ with HasHistory {
   }
   
   /**
+   * Specify whether to stop root execution on errors.
+   * 
+   * @param enable	If true, stop root execution if an error occurs.  
+   *                If false, do not.
+   */
+  def crashRoot_=(enable: Boolean) {
+    _crashRoot = enable
+  }
+  
+  /**
    * Determine whether tracing is enabled.
    */
   def trace = _trace
@@ -424,6 +444,11 @@ with HasHistory {
    * Determine which parser to use
    */
   def toggle = _toggle
+  
+  /**
+   * Determine if root execution stops when an error occurs.
+   */
+  def crashRoot = _crashRoot
   
   /**
    * Register a handler.  This handler will be placed at the front of the

--- a/Elision/src/ornl/elision/repl/ERepl.scala
+++ b/Elision/src/ornl/elision/repl/ERepl.scala
@@ -567,10 +567,6 @@ class ERepl extends Processor {
           ReplActor ! ("Eva", "newTree", line)
           
           execute(line)
-	
-          // send the completed rewrite tree to the GUI's actor
-          if(ReplActor.guiActor != null && !ReplActor.disableGUIComs && line != "")
-              ReplActor ! ("Eva", "finishTree", None)
         } catch {
           case ornl.elision.util.ElisionException(msg) =>
             console.error(msg)
@@ -590,6 +586,10 @@ class ERepl extends Processor {
             if (getProperty[Boolean]("stacktrace")) th.printStackTrace()
             coredump("Internal error.", Some(th))
         }
+        
+        // send the completed rewrite tree to the GUI's actor
+        if(ReplActor.guiActor != null && !ReplActor.disableGUIComs && line != "")
+          ReplActor ! ("Eva", "finishTree", None)
       }
     } // Forever read, eval, print.
   }

--- a/Elision/test/ornl/elision/core/MemoTest.scala
+++ b/Elision/test/ornl/elision/core/MemoTest.scala
@@ -45,9 +45,9 @@ import java.util.concurrent.TimeUnit
  *
  */
 class MemoTest extends AssertionsForJUnit {
- val numObjs = 8000 
+ val numObjs = 30000 
  val ccaSize = 120
- val numThreads = 10
+ val numThreads = 20
   
   
   /**


### PR DESCRIPTION
...c operation to stop all the way up to the root level instead of just skipping the bad inc'ed file. crashinc() is ON by default.
