### PR TITLE
1. In Apply.scala and RuleLibrary.scala, use a 10 second timeout for ope...

### DIFF
--- a/Elision/src/ornl/elision/core/Apply.scala
+++ b/Elision/src/ornl/elision/core/Apply.scala
@@ -37,6 +37,7 @@
 * */
 package ornl.elision.core
 
+import scala.compat.Platform
 import scala.collection.mutable.ListBuffer
 import scala.collection.mutable.HashSet
 import scala.collection.mutable.Stack
@@ -181,7 +182,12 @@ object Apply {
 
     // Temporarily disable rewrite timeouts.
     val oldTimeout = BasicAtom.timeoutTime.value
-    BasicAtom.timeoutTime.value = -1L
+    if (BasicAtom.rewriteTimedOut) {
+      BasicAtom.timeoutTime.value = -1L
+    }
+    else {
+      BasicAtom.timeoutTime.value = Platform.currentTime + 10*1000
+    }
 
     // Do not try to compute if metaterms are present.
     var retval: BasicAtom = null

--- a/Elision/src/ornl/elision/core/BasicAtom.scala
+++ b/Elision/src/ornl/elision/core/BasicAtom.scala
@@ -38,7 +38,7 @@
 package ornl.elision.core
 
 import scala.collection.immutable.HashSet
-import scala.collection.mutable.{HashSet => MutableHashSet}
+import scala.collection.mutable.{HashSet => MutableHashSet, BitSet}
 import scala.compat.Platform
 import scala.util.DynamicVariable
 import ornl.elision.util.PropertyManager
@@ -191,7 +191,14 @@ trait Applicable {
  */
 abstract class BasicAtom extends HasOtherHash {
   import scala.collection.mutable.{Map => MMap}
-  
+
+  /**
+   * The rulesets with respect to which this atom is clean. If this is
+   * not None the atom has already been rewritten with some set of
+   * rulesets. If None, the atom has never been rewritten.
+   */
+  var cleanRulesets: Option[BitSet] = None
+
   /** The type for the atom. */
   val theType: BasicAtom
   
@@ -579,7 +586,7 @@ object BasicAtom {
     // executor than what Elision is actually using.
     val rewrite_timeout = knownExecutor.getProperty[BigInt]("rewrite_timeout").asInstanceOf[BigInt]
     //println("** rewrite_timeout == " + rewrite_timeout)
-    if ((rewrite_timeout > 0) && (timeoutTime.value == -1)) {
+    if ((rewrite_timeout > 0) && (timeoutTime.value <= -1)) {
 
       // The time at which things time out is the current time plus
       // the maximum amount of time to rewrite things.

--- a/Elision/src/ornl/elision/core/Operator.scala
+++ b/Elision/src/ornl/elision/core/Operator.scala
@@ -37,6 +37,7 @@
 * */
 package ornl.elision.core
 
+import scala.compat.Platform
 import scala.collection.immutable.HashMap
 import scala.collection.mutable.ListBuffer
 import ornl.elision.util.ElisionException
@@ -927,9 +928,14 @@ protected class SymbolicOperator protected (sfh: SpecialFormHolder,
    */
   def doApply(rhs: BasicAtom, bypass: Boolean): BasicAtom = {
 
-    // Temporarily disable rewrite timeouts.
+    // Temporarily disable rewrite timeouts if already timed out.
     val oldTimeout = BasicAtom.timeoutTime.value
-    BasicAtom.timeoutTime.value = -1L
+    if (BasicAtom.rewriteTimedOut) {
+      BasicAtom.timeoutTime.value = -1L
+    }
+    else {
+      BasicAtom.timeoutTime.value = Platform.currentTime + 10*1000
+    }
 
     rhs match {
       case args: AtomSeq =>


### PR DESCRIPTION
...rations that

really need to complete rather than temporarily disabling timeouts.
2. In BasicAtom.scala and RuleLibrary.scala, added a cleanRulesets field that tracks
   the rulesets for which an atom is "clean". When rewriting, if the rulesets with
   which to rewrite is a subset of the rulesets with which the atom has already been
   rewritten, don't rewrite the atom.
