### PR TITLE
This commit contains various optimizations and simplifications.

### DIFF
--- a/Elision/src/ornl/elision/core/AtomSeq.scala
+++ b/Elision/src/ornl/elision/core/AtomSeq.scala
@@ -39,13 +39,13 @@ package ornl.elision.core
 
 import scala.collection.mutable.HashSet
 import scala.collection.IndexedSeq
-
 import ornl.elision.util.OmitSeq
 import ornl.elision.core.BasicAtomComparator._
 import ornl.elision.core.matcher.AMatcher
 import ornl.elision.core.matcher.CMatcher
 import ornl.elision.core.matcher.ACMatcher
 import ornl.elision.core.matcher.SequenceMatcher
+import scala.collection.mutable.HashMap
 
 /**
  * Fast access to an untyped empty sequence.
@@ -54,7 +54,7 @@ object EmptySeq extends AtomSeq(NoProps, IndexedSeq())
 
 /**
  * An atom sequence is just that: a sequence of atoms.
- * 
+ *
  * == Properties ==
  * Atom sequences may have properties like operators.  That is, they may be
  * commutative, associative, idempotent, and may have absorbers and identities.
@@ -62,56 +62,56 @@ object EmptySeq extends AtomSeq(NoProps, IndexedSeq())
  * example, a list that is associative, commutative, and idempotent is
  * essentially a set.  If not idempotent, it is a multiset.  Properties are
  * specified with an algebraic properties object.
- * 
+ *
  * == Use ==
- * Create a list by specifying the properties and then providing a list of 
+ * Create a list by specifying the properties and then providing a list of
  * atoms to include in the list.  The atoms are specified using an instance
  * of an `IndexedSeq`.
- * 
+ *
  * @param props		The properties for this atom sequence.
  * @param xatoms	The sequence of atoms in this sequence.  Note that, depending
  * on the specified properties, the stored sequence may be different.
  */
 class AtomSeq(val props: AlgProp, orig_xatoms: IndexedSeq[BasicAtom])
-extends BasicAtom with IndexedSeq[BasicAtom] {
+  extends BasicAtom with IndexedSeq[BasicAtom] {
   require(props != null)
-  
+
   /**
    * Whether this sequence is specified to be associative.  Note that false here
    * just means the sequence was not marked as associative; it's associativity
    * may be unspecified.
    */
   lazy val associative = props.isA(false)
-  
+
   /**
    * Whether this sequence is specified to be commutative.  Note that false here
    * just means the sequence was not marked as commutative; it's associativity
    * may be unspecified.
    */
   lazy val commutative = props.isC(false)
-  
+
   /**
    * Whether this sequence is specified to be idempotent.  Note that false here
    * just means the sequence was not marked as idempotent; it's associativity
    * may be unspecified.
    */
   lazy val idempotent = props.isI(false)
-  
+
   /**
    * The absorber for this sequence, if any.
    */
   lazy val absorber = props.absorber
-  
+
   /**
    * The identity for this sequence, if any.
    */
   lazy val identity = props.identity
 
   /**
-   * The names of the operators appearing in the sequence. This is
-   * populated in process().
+   * The names and number of occurrences of the operators appearing in the 
+   * sequence. This is populated in process().
    */
-  private var _operators : java.util.HashSet[String] = null
+  private lazy val _operators: HashMap[String, Int] = new HashMap[String, Int]
 
   /** Precomputed version of isConstant. */
   private var _isConstant = false
@@ -122,7 +122,7 @@ extends BasicAtom with IndexedSeq[BasicAtom] {
    * This is a mapping from constants in the sequence to the (zero-based)
    * index of the constant.
    */
-  lazy val constantMap : scala.collection.mutable.OpenHashMap[BasicAtom, Int] = {
+  lazy val constantMap: scala.collection.mutable.OpenHashMap[BasicAtom, Int] = {
     var r = scala.collection.mutable.OpenHashMap[BasicAtom, Int]()
     _isConstant = true
     _gotIsConstant = true
@@ -133,16 +133,17 @@ extends BasicAtom with IndexedSeq[BasicAtom] {
     r
   }
 
-  /** Compute these things when processing the atoms in process().
-   * 
-   * Determine whether we have to sort the atoms.  If we know the list is
+  /**
+   * Compute these things when processing the atoms in process().
+   *
+   * Determine whether we have to sort the atoms.  If the list is
    * commutative, then we have to sort it.
    */
-  val atoms : OmitSeq[BasicAtom] = (if (props.isC(false)) process(props, orig_xatoms).sorted(BasicAtomComparator)
-               else process(props, orig_xatoms))
+  val atoms: OmitSeq[BasicAtom] = (if (props.isC(false)) process(props, orig_xatoms).sorted(BasicAtomComparator)
+                                   else process(props, orig_xatoms))
 
   import SymbolicOperator.LIST
-  
+
   /**
    * The type of a sequence is derived from looking at the types of the
    * elements of the sequence.  If the elements all have the same type,
@@ -150,7 +151,7 @@ extends BasicAtom with IndexedSeq[BasicAtom] {
    * or the sequence is empty, then the type is ANY.
    */
   lazy val theType = {
-    if (atoms.length == 0) LIST(ANY) 
+    if (atoms.length == 0) LIST(ANY)
     else {
       val aType = atoms(0).theType
       if (atoms.forall(aType == _.theType)) LIST(aType) else LIST(ANY)
@@ -164,56 +165,59 @@ extends BasicAtom with IndexedSeq[BasicAtom] {
   lazy val deBruijnIndex = atoms.foldLeft(0)(_ max _.deBruijnIndex)
   lazy val depth = atoms.foldLeft(0)(_ max _.depth) + 1
 
-  def hasOperator(op : Operator) = {
-    ((_operators == null) || (_operators.contains(op.name)))
+  def hasOperator(op: Operator) = {
+    _operators.contains(op.name)
   }
 
-  def hasOperator(op : String) = {
-    ((_operators == null) || (_operators.contains(op)))
+  def hasOperator(op: String) = {
+    _operators.contains(op)
+  }
+
+  def operatorCount(op: Operator): Int = {
+    _operators.getOrElse(op.name, 0)
+  }
+
+  def operatorCount(op: String): Int = {
+    _operators.getOrElse(op, 0)
   }
 
   /**
    * Process the atoms and build the new sequence.  This reduces any included
    * associative sequences, and incidentally makes sure the result is an
    * `OmitSeq`.
-   * 
+   *
    * This method is used during instance construction.
-   * 
+   *
    * @param props	The properties.
    * @param atoms	The atoms.
    * @return	The possibly-new sequence.
    */
   private def process(props: AlgProp,
-                      xatoms: IndexedSeq[BasicAtom]): OmitSeq[BasicAtom] = {
-
+    xatoms: IndexedSeq[BasicAtom]): OmitSeq[BasicAtom] = {
     // If the list is associative, has an identity, has an absorber,
     // or is idempotent we process it.
     val assoc = props.isA(false)
     val ident = props.identity.getOrElse(null)
     val absor = props.absorber.getOrElse(null)
     val idemp = props.isI(false)
+    lazy val seen: HashSet[BasicAtom] = new HashSet[BasicAtom]
     var atoms: OmitSeq[BasicAtom] = xatoms
-    var seen : java.util.HashSet[BasicAtom] = new java.util.HashSet[BasicAtom]
     if (assoc || ident != null || absor != null || idemp) {
-      _operators = new java.util.HashSet[String]
       var index = 0
       var finalIndex = 0
-      var flattened_a = false
       while (index < atoms.size) {
         val atom = atoms(index)
-
         // Track the name of the operator appearing in the sequence.
         atom match {
-          case OpApply(opref, opargs, binds) => _operators.add(opref.operator.name)
+          case OpApply(opref, _, _) => _operators += (opref.operator.name -> (_operators.getOrElse(opref.operator.name, 0) + 1))
           case _ =>
-        }        
+        }
 
         if (absor == atom) {
-
           // Found the absorber.  It must be the only thing in the sequence.
-          _operators = new java.util.HashSet[String]
-           atom match {
-            case OpApply(opref, opargs, binds) => _operators.add(opref.operator.name)
+          _operators.clear
+          atom match {
+            case OpApply(opref, _, _) => _operators += (opref.operator.name -> (_operators.getOrElse(opref.operator.name, 0) + 1))
             case _ =>
           }
 
@@ -222,17 +226,13 @@ extends BasicAtom with IndexedSeq[BasicAtom] {
 
         // The atom is not the identity?
         if (ident != atom) {
-          var flattened = false
           if (assoc) atom match {
             case AtomSeq(oprops, args) if props == oprops =>
-
               // Add the arguments directly to this list.  We can assume this
               // list has already been processed, so no deeper checking is
               // needed.
               atoms = atoms.omit(index)
               atoms = atoms.insert(index, args)
-              flattened = true
-              flattened_a =true
               // We have not yet checked the flattened arguments for
               // idempotency against the unflattened arguments. Therefore
               // we cannot skip the 1st flattened argument when checking
@@ -241,16 +241,14 @@ extends BasicAtom with IndexedSeq[BasicAtom] {
               finalIndex -= 1
 
             case _ =>
-              // Nothing to do in this case.
+            // Nothing to do in this case.
           }
 
           // Handle idempotency. If idempotent and the current argument
           // has already been seen, skip it.
-          if (idemp && !flattened) {
-
+          if (idemp) {
             // Have we already seen this argument?
             if (seen.contains(atom)) {
-
               // Skip the argument due to idempotency.
               atoms = atoms.omit(index)
               finalIndex -= 1
@@ -259,9 +257,7 @@ extends BasicAtom with IndexedSeq[BasicAtom] {
             // Track that we have seen this argument.
             seen.add(atom)
           }
-        }
-
-        // The atom IS the identity. Skip it.
+        } // The atom IS the identity. Skip it.
         else {
           atoms = atoms.omit(index)
           finalIndex -= 1
@@ -272,22 +268,22 @@ extends BasicAtom with IndexedSeq[BasicAtom] {
         finalIndex += 1
       } // Run through all arguments.
     }
-    
+
     // Done!
     return atoms
   }
-  
+
   /**
    * Get an element of this sequence by (zero-based) index.
-   * 
+   *
    * @param idx	The index.
    * @return	The requested element.
    */
   def apply(idx: Int) = atoms(idx)
-  
+
   /** The length of this sequence. */
   def length = atoms.length
-  
+
   /**
    * Try to match this atom sequence, as a pattern, against the provided atom.
    * Atom sequences only match other atom sequences, and they only match if
@@ -297,7 +293,7 @@ extends BasicAtom with IndexedSeq[BasicAtom] {
    * correctly type subsequences.
    */
   def tryMatchWithoutTypes(subject: BasicAtom, binds: Bindings,
-                           hints: Option[Any]): Outcome = {
+    hints: Option[Any]): Outcome = {
     if (BasicAtom.rewriteTimedOut) {
       Fail("Timed out", this, subject)
     } else {
@@ -311,7 +307,7 @@ extends BasicAtom with IndexedSeq[BasicAtom] {
         }
         case _ => None
       }
-      
+
       // Atom sequences only match other atom sequences.
       subject match {
         case as: AtomSeq =>
@@ -319,7 +315,7 @@ extends BasicAtom with IndexedSeq[BasicAtom] {
           // sequences using the appropriate matching algorithm based on the
           // properties.
           def doMatchSequences(usebinds: Bindings): Outcome = {
-        	  // Now we have to decide how to compare the two sequences.  Note that
+            // Now we have to decide how to compare the two sequences.  Note that
             // if the properties matching changes, this will like have to change,
             // too, to use the matched properties.
             if (associative) {
@@ -336,31 +332,31 @@ extends BasicAtom with IndexedSeq[BasicAtom] {
               }
             }
           }
-        
+
           // Match properties.  This may alter the bindings.
           props.tryMatch(as.props, binds) match {
             case fail: Fail =>
               Fail("Sequence properties do not match.", this, subject,
-                  Some(fail))
-              
+                Some(fail))
+
             case Match(newbinds) =>
               doMatchSequences(newbinds)
-              
+
             case Many(iter) =>
               Outcome.convert(iter ~> (doMatchSequences _),
-                  Fail("Sequence properties do not match.", this, subject))
+                Fail("Sequence properties do not match.", this, subject))
           }
-        
+
         case _ => Fail("An atom sequence may only match another atom sequence.",
-                       this, subject)
+          this, subject)
       }
     }
-	}
+  }
 
   def rewrite(binds: Bindings): (AtomSeq, Boolean) = {
     // Rewrite the properties.
     val (newprop, pchanged) = props.rewrite(binds)
-    
+
     // We must rewrite every child atom, and collect them into a new sequence.
     var schanged = false
     val newseq = atoms map {
@@ -369,7 +365,7 @@ extends BasicAtom with IndexedSeq[BasicAtom] {
         schanged |= changed
         newatom
     }
-    
+
     // If anything changed, make a new sequence.
     if (pchanged || schanged) {
       (new AtomSeq(newprop, newseq), true)
@@ -377,7 +373,7 @@ extends BasicAtom with IndexedSeq[BasicAtom] {
       (this, false)
     }
   }
-  
+
   def replace(map: Map[BasicAtom, BasicAtom]) = {
     map.get(this) match {
       case Some(atom) =>
@@ -408,15 +404,15 @@ extends BasicAtom with IndexedSeq[BasicAtom] {
   /**
    * Provide a "naked" version of the sequence, without the parens and property
    * indicators.
-   * 
+   *
    * @return	The elements of the sequence, separated by commas.  Items internal
    * 					to the sequence may themselves be lists; that is okay, since the
    * 					parse string is used for those atoms.
    */
   def toNakedString = atoms.mkParseString("", ", ", "")
-  
+
   override lazy val hashCode = atoms.hashCode * 12289 + props.hashCode
-  override lazy val otherHashCode = atoms.otherHashCode + 8191*props.otherHashCode
+  override lazy val otherHashCode = atoms.otherHashCode + 8191 * props.otherHashCode
 
   /**
    * Two sequences are equal iff their properties and atoms are equal.
@@ -434,33 +430,33 @@ extends BasicAtom with IndexedSeq[BasicAtom] {
  * Simplified construction and matching for atom sequences.
  */
 object AtomSeq {
-  
+
   /** An empty atom sequence with no properties. */
   val EmptySeq = new AtomSeq(NoProps, IndexedSeq[BasicAtom]())
-  
+
   /** Get an empty atom sequence with no properties. */
   def apply() = EmptySeq
-  
+
   /**
    * Match an atom sequence's parts.
-   * 
+   *
    * @param seq	The sequence.
    * @return	The properties and the atoms.
    */
   def unapply(seq: AtomSeq) = Some(seq.props, seq.atoms)
-  
+
   /**
    * Make a new atom sequence with the given properties and children.
-   * 
+   *
    * @param props	The properties.
    * @param atoms	The atoms.
    */
   def apply(props: AlgProp, seq: IndexedSeq[BasicAtom]) =
     new AtomSeq(props, seq)
-  
+
   /**
    * Make a new atom sequence with the given properties and children.
-   * 
+   *
    * @param props	The properties.
    * @param atoms	The atoms.
    */
@@ -470,7 +466,7 @@ object AtomSeq {
 
 /**
  * Improve matching of atom sequences as lists of atoms.
- * 
+ *
  * This is intended for use in matching.  The general form is:
  * {{{
  * args match {
@@ -482,7 +478,7 @@ object AtomSeq {
 object Args {
   /**
    * Allow matching of an atom sequence as a sequence.
-   * 
+   *
    * @param seq	The atom sequence.
    * @return	The children as a matchable sequence.
    */

--- a/Elision/src/ornl/elision/core/BasicAtomComparator.scala
+++ b/Elision/src/ornl/elision/core/BasicAtomComparator.scala
@@ -116,15 +116,12 @@ object BasicAtomComparator extends Ordering[BasicAtom] {
         (atom1.otherHashCode == atom2.otherHashCode) &&
         (if (_riskyEqual) true else other)
     )
-    //if(BasicAtomComparator.compare(atom1, atom2) == 0) true 
-    //else false
   }
   
 
   
   def fcmp(atom1: BasicAtom, atom2: BasicAtom) = {
-    if (((atom1.hashCode compare atom2.hashCode) == 0) &&
-        ((atom1.otherHashCode compare atom2.otherHashCode) == 0)) {
+    if(feq(atom1, atom2, false)){
         0
     }
     else {
@@ -166,203 +163,32 @@ object BasicAtomComparator extends Ordering[BasicAtom] {
    */
   def compare(left: BasicAtom, right: BasicAtom): Int = {
 
-    // First check the ordinals.
+    // Compare the atoms and store the result for possible later use.
+    // This explicitly breaks a potential unbounded
+    // recursion caused by the LIST(x) operator.  The problems looks like this
+    // (for reference): LIST(x) => LIST:OPREF . %(x), but the argument is also
+    // a LIST(x), so we have an unbounded recursion. 
+    val hashcmp = fcmp(left, right)
+    if(hashcmp == 0) return 0
+    
+    // Check the ordinals.
     val lo = getOrdinal(left)
     var sgn = (getOrdinal(right) - lo).signum
     if (sgn != 0) return sgn
-
 
     // Watch for root types!
     if (left == TypeUniverse) {
       if (right == TypeUniverse) return 0
       else return 1
     } else if (right == TypeUniverse) return -1
-
     
-
-    // Too slow.
-    
-    // Test for fast equality.  This explicitly breaks a potential unbounded
-    // recursion caused by the LIST(x) operator.  The problems looks like this
-    // (for reference): LIST(x) => LIST:OPREF . %(x), but the argument is also
-    // a LIST(x), so we have an unbounded recursion.
-    if (feq(left, right, false)) {
-      return 0
-    }
-    
-    return fcmp(left, right)
-    
-    /*
-    // Ordinals did not solve the problem; the two atoms have the same ordinal.
-    // Try to order the atoms by their types.  Watch for recursion!
+    //If ordinals and root types don't get us anywhere, use the atom types
     if (!(left.theType eq right.theType)) {
       if (!(left.theType eq left) && !(right.theType eq right)) {
         sgn = compare(left.theType, right.theType)
         if (sgn != 0) return sgn
       }
     }
-    
-    // The types did not resolve anything.  We have to try more specific
-    // tests.
-    lo match {
-      case 0 =>
-        // Compare literals by their values.  We already know the two literals
-        // have the same type... but might be different classes!
-        return left match {
-          case llit: IntegerLiteral => right match {
-            case rlit: IntegerLiteral => llit.value.compare(rlit.value)
-            case _ => -1
-          }
-          case llit: BitStringLiteral => right match {
-            case rlit: BitStringLiteral =>
-              val (l1, l2) = llit.value
-              val (r1, r2) = rlit.value
-              sgn = l1 compare r1
-              if (sgn != 0) return sgn
-              sgn = l2 compare r2
-              return l2 compare r2
-          }
-          case llit: BooleanLiteral => right match {
-            case rlit: BooleanLiteral => llit.value.compare(rlit.value)
-            case _ => -1
-          }
-          case llit: StringLiteral => right match {
-            case rlit: IntegerLiteral => 1
-            case rlit: StringLiteral => llit.value.compare(rlit.value)
-            case _ => -1
-          }
-          case llit: SymbolLiteral => right match {
-            case rlit: IntegerLiteral => 1
-            case rlit: StringLiteral => 1
-            case rlit: SymbolLiteral => llit.value.name.compare(rlit.value.name)
-            case _ => -1
-          }
-          case llit: FloatLiteral => right match {
-            case rlit: IntegerLiteral => 1
-            case rlit: StringLiteral => 1
-            case rlit: SymbolLiteral => 1
-            case rlit: FloatLiteral =>
-              val (l1,l2,l3) = llit.value
-              val (r1,r2,r3) = rlit.value
-              sgn = l1 compare r1
-              if (sgn != 0) return sgn
-              sgn = l2 compare r2
-              if (sgn != 0) return sgn
-              return l3 compare r3
-          }
-        }
-        
-      case 1 =>
-        // Comparing algebraic properties.  We just compare them piece by
-        // piece.
-        val lap = left.asInstanceOf[AlgProp]
-        val rap = right.asInstanceOf[AlgProp]
-        sgn = compare(lap.absorber, rap.absorber)
-        if (sgn != 0) return sgn
-        sgn = compare(lap.associative, rap.associative)
-        if (sgn != 0) return sgn
-        sgn = compare(lap.commutative, rap.commutative)
-        if (sgn != 0) return sgn
-        sgn = compare(lap.idempotent, rap.idempotent)
-        if (sgn != 0) return sgn
-        return compare(lap.identity, rap.identity)
-        
-      case 2 =>
-        // Compare metavariables.  We just order them by name and ignore all else.
-        return left.asInstanceOf[MetaVariable].name compare right.asInstanceOf[MetaVariable].name
-        
-      case 3 =>
-        // Compare variables.  We just order them by name and ignore all else.
-        return left.asInstanceOf[Variable].name compare right.asInstanceOf[Variable].name
-        
-      case 4 =>
-        // Compare two applies.  Compare the operators and then the arguments.
-        val lap = left.asInstanceOf[Apply]
-        val rap = right.asInstanceOf[Apply]
-        sgn = compare(lap.op, rap.op)
-        if (sgn != 0) return sgn
-        return compare(lap.arg, rap.arg)
-        
-      case 5 =>
-        // Compare two atom sequences.  We order by algebraic properties, then
-        // by length, and finally by order of the items.
-        val las = left.asInstanceOf[AtomSeq]
-        val ras = right.asInstanceOf[AtomSeq]
-        sgn = compare(las.props, ras.props)
-        if (sgn != 0) return sgn
-        sgn = (las.length - ras.length).signum
-        if (sgn != 0) return sgn
-        // Now we have to order by the elements.  We already know the sequences
-        // are the same length.  Walk them and try to find some case where they
-        // are distinct.
-        var index = 0
-        for (index <- 0 until las.length) {
-          sgn = compare(las(index), ras(index))
-          if (sgn != 0) return sgn
-        } // Compare all elements of the sequences.
-        return 0
-        
-      case 6 =>
-        // Compare two bindings atoms.  Ordering bindings atoms is tricky.
-        // First try ordering them my number of bindings.
-        val lbinds = left.asInstanceOf[BindingsAtom].mybinds
-        val rbinds = right.asInstanceOf[BindingsAtom].mybinds
-        sgn = (lbinds.size - rbinds.size).signum
-        if (sgn != 0) return sgn
-        // Now we have to actually compare the bindings.  To do this we
-        // merge the key sets and then order the result.  Then we compare
-        // the values for every key.
-        val keyset = lbinds.keySet.union(rbinds.keySet).toIndexedSeq.sorted
-        for (key <- keyset) {
-          sgn = compare(lbinds.get(key), rbinds.get(key))
-          if (sgn != 0) return sgn
-        } // Compare all elements.
-        return 0
-        
-      case 7 =>
-        // Compare two lambdas.  We order them by body only, since the
-        // DeBruijn indices replace the parameters.
-        return compare(left.asInstanceOf[Lambda].body,
-            right.asInstanceOf[Lambda].body)
-            
-      case 8 =>
-        // Compare two map pairs.  We just compare the elements.
-        val lmp = left.asInstanceOf[MapPair]
-        val rmp = right.asInstanceOf[MapPair]
-        sgn = compare(lmp.left, rmp.left)
-        if (sgn != 0) return sgn
-        return compare(lmp.right, rmp.right)
-        
-      case 9 =>
-        // Compare two match atoms.
-        return compare(left.asInstanceOf[MatchAtom].pattern,
-            right.asInstanceOf[MatchAtom].pattern)
-            
-      case 10 =>
-        // Compare two special forms.
-        val lsf = left.asInstanceOf[SpecialForm]
-        val rsf = right.asInstanceOf[SpecialForm]
-        sgn = compare(lsf.tag, rsf.tag)
-        if (sgn != 0) return sgn
-        return compare(lsf.content, rsf.content)
-        
-      case 11 =>
-        // Comparing two ruleset references.  They sort by name.
-        return left.asInstanceOf[RulesetRef].name.compare(
-            right.asInstanceOf[RulesetRef].name)
-        
-      case 12 =>
-        // Comparing two operator references.  They sort by name.
-        return left.asInstanceOf[OperatorRef].name.compare(
-            right.asInstanceOf[OperatorRef].name)
-        
-      case _ =>
-        // Something annoying has happened.
-        throw new ornl.elision.util.ElisionException(left.loc,
-            "ERROR: No sort order defined for: " + left.toParseString)
-    }
-    
-    // If we get here, something is wrong.  Bail out.
-    */
+    hashcmp
   }
 }

--- a/Elision/src/ornl/elision/core/Operator.scala
+++ b/Elision/src/ornl/elision/core/Operator.scala
@@ -40,7 +40,7 @@ package ornl.elision.core
 import scala.compat.Platform
 import scala.collection.immutable.HashMap
 import scala.collection.mutable.ListBuffer
-import scala.collection.mutable.{Set => MSet}
+import scala.collection.mutable.{ Set => MSet }
 import scala.collection.mutable.Stack
 import scala.collection.mutable.Queue
 import scala.tools.nsc.interpreter.Results
@@ -61,7 +61,7 @@ import ornl.elision.util.FastLinkedList
  * @param msg	The human-readable message describing the problem.
  */
 class ArgumentListException(loc: Loc, msg: String)
-extends ElisionException(loc, msg)
+  extends ElisionException(loc, msg)
 
 /**
  * The native handler could not be parsed.
@@ -70,13 +70,13 @@ extends ElisionException(loc, msg)
  * @param msg	The human-readable message describing the problem.
  */
 class NativeHandlerException(loc: Loc, msg: String)
-extends ElisionException(loc, msg)
+  extends ElisionException(loc, msg)
 
 /**
  * A little class to use to pass data back and forth from the subordinate
  * interpreter.  Since a native handler must return an atom, this is the
  * return value of the passed closure.
- * 
+ *
  * A native handler is parsed by a subordinate Scala interpreter.  This has
  * to bind something available in *this* scope - specifically it binds up
  * an instance of `HandHolder` and passes it back.  Initially this holds
@@ -90,7 +90,7 @@ class HandHolder(
 /**
  * Data block and special functions provided to a native handler.  A native
  * handler takes an instance of this class and hands back an atom.
- * 
+ *
  * Certain information is populated based on the current __implicit__
  * `Executor` instance.  This is done at construction time.
  *
@@ -150,20 +150,20 @@ abstract class Operator(
   extends SpecialForm(sfh.loc, sfh.tag, sfh.content) with Applicable {
   /**
    * Apply the operator to the given sequence of basic atoms as arguments.
-   * 
+   *
    * @param atoms   The arguments, in order.
    * @return  The constructed atom.
    */
   def apply(atoms: BasicAtom*): BasicAtom
-  
+
   /**
    * Proxy to the parent match method, but turn this operator into an operator
    * reference in the process.
    */
   override def tryMatchWithoutTypes(
-      subject: BasicAtom, binds: Bindings, hints: Option[Any]) =
+    subject: BasicAtom, binds: Bindings, hints: Option[Any]) =
     super.tryMatchWithoutTypes(subject, binds, Some(OperatorRef(this)))
-  }
+}
 
 /**
  * Provide construction and matching for operators.
@@ -181,8 +181,8 @@ object Operator {
   def apply(sfh: SpecialFormHolder): Operator = {
     val bh = sfh.requireBindings
     bh.check(Map("name" -> true, "cases" -> false, "params" -> false,
-        "type" -> false, "description" -> false, "detail" -> false,
-        "evenmeta" -> false, "handler" -> false))
+      "type" -> false, "description" -> false, "detail" -> false,
+      "evenmeta" -> false, "handler" -> false))
     if (bh.either("cases", "params") == "cases") {
       CaseOperator(sfh)
     } else {
@@ -234,14 +234,14 @@ class OperatorRef(val operator: Operator) extends BasicAtom with Applicable {
    * Operator references cannot be rewritten.  This is actually why they exist!
    */
   def rewrite(binds: Bindings) = (this, false)
-   
+
   def replace(map: Map[BasicAtom, BasicAtom]) = map.get(this) match {
     case None => (this, false)
     case Some(atom) => (atom, true)
   }
 
   def tryMatchWithoutTypes(subject: BasicAtom, binds: Bindings,
-      hints: Option[Any]) =
+    hints: Option[Any]) =
     if (subject == this) {
       Match(binds)
     } else subject match {
@@ -275,7 +275,7 @@ class OperatorRef(val operator: Operator) extends BasicAtom with Applicable {
  * Make and match operator references.
  */
 object OperatorRef {
-  
+
   /**
    * Extract the operator from the reference.
    *
@@ -283,7 +283,7 @@ object OperatorRef {
    * @return	The referenced operator.
    */
   def unapply(ref: OperatorRef) = Some(ref.operator)
-  
+
   /**
    * Make a reference for an operator.
    *
@@ -352,7 +352,7 @@ object CaseOperator {
    * @return	A triple of the name, type, and cases.
    */
   def unapply(co: CaseOperator) = Some((co.name, co.theType, co.cases,
-      co.description, co.detail, co.evenMeta))
+    co.description, co.detail, co.evenMeta))
 }
 
 /**
@@ -433,7 +433,7 @@ class CaseOperator private (sfh: SpecialFormHolder,
       case other =>
         // We have to do one more thing.  We need to bind $__ to this operator,
         // and $_ to the original argument list, and then rewrite the result.
-        val binds = Bindings("_"->args, "__"->this)
+        val binds = Bindings("_" -> args, "__" -> this)
         other.rewrite(binds)._1
     }
   }
@@ -448,7 +448,7 @@ class CaseOperator private (sfh: SpecialFormHolder,
  * @param binds		Bindings of parameter to argument.
  */
 class ApplyInfo(val op: SymbolicOperator, val args: AtomSeq,
-    val binds: Bindings)
+  val binds: Bindings)
 
 /**
  * Construction and matching of typed symbolic operators.
@@ -484,7 +484,7 @@ object TypedSymbolicOperator {
     new TypedSymbolicOperator(sfh, name, typ, params,
       description, detail, evenMeta, handlertxt)
   }
-  
+
   /**
    * Make a typed symbolic operator from the provided parts.
    *
@@ -525,7 +525,7 @@ object TypedSymbolicOperator {
    */
   def unapply(so: TypedSymbolicOperator) =
     Some((so.name, so.typ, so.params, so.description, so.detail,
-        so.evenMeta, so.handlertxt))
+      so.evenMeta, so.handlertxt))
 }
 
 /**
@@ -550,7 +550,7 @@ class TypedSymbolicOperator private (sfh: SpecialFormHolder,
   description: String, detail: String, evenMeta: Boolean,
   handlertxt: Option[String])
   extends SymbolicOperator(sfh, name, typ, params,
-      description, detail, evenMeta, handlertxt) {
+    description, detail, evenMeta, handlertxt) {
   /**
    * The type of an operator is a mapping from the operator domain to the
    * operator codomain.
@@ -569,45 +569,45 @@ object SymbolicOperator {
   // Get the current class path and convert it into a proper path expression.
   private val _urls =
     java.lang.Thread.currentThread.getContextClassLoader match {
-    case cl: java.net.URLClassLoader => cl.getURLs.toList
-    case other => sys.error("classloader is not a URLClassLoader. " +
+      case cl: java.net.URLClassLoader => cl.getURLs.toList
+      case other => sys.error("classloader is not a URLClassLoader. " +
         "It is a " + other.getClass.getName)
-  }
+    }
   private val _classpath = (_urls.map(_.getPath)).mkString(_ps)
 
   // Build a settings with the correct classpath.
-  private val _settings = new scala.tools.nsc.Settings(knownExecutor.console.emitln _) 
+  private val _settings = new scala.tools.nsc.Settings(knownExecutor.console.emitln _)
   _settings.classpath.value = _classpath
-  
+
   /** Make an interpreter. */
   private val _main = new scala.tools.nsc.interpreter.IMain(_settings) {}
 
   // Make the core package available.
   _main.beQuietDuring(_main.interpret("import ornl.elision.core._"))
-  
+
   // Time the compilation of native handlers.
   import ornl.elision.util.Timeable
   private val _timer = new Timeable {
     timing = true
     def reportElapsed() = {}
-  }  
+  }
   private val _ncomp = new NativeCompiler
 
   /**
    * Compile Scala code to a native handler.
-   * 
+   *
    * @param op            The operator to get this native handler.
    * @param handlertxt    The optional text to compile.
    * @return  The optional handler result.
    */
   private def compileHandler(op: SymbolicOperator,
-                             code: Option[String]): Option[ApplyData => BasicAtom] = {
+    code: Option[String]): Option[ApplyData => BasicAtom] = {
 
     // Fetch the handler text.
     if (code.isDefined) {
       var handlertxt = code.get.split("\n")
       def removeBlankLines(txt: Array[String]) =
-        for(line <- txt if line.trim.length > 0) yield line
+        for (line <- txt if line.trim.length > 0) yield line
       //The compiler doesn't like blank lines, so we remove them.      
       handlertxt = removeBlankLines(handlertxt)
       // Concatenate all the lines into a single block of code. Each element
@@ -616,7 +616,7 @@ object SymbolicOperator {
       var handlerblock = ("" /: handlertxt)(_ + _ + "\n")
       if (handlerblock.length > 0 && handlerblock(0) == '|')
         handlerblock = handlerblock.stripMargin('|')
-        
+
       // Compile the handler, if we were given one.
       if (handlerblock != "") {
         return Some(_timer.time {
@@ -624,7 +624,7 @@ object SymbolicOperator {
         })
       }
     } // Handler has text.
-    
+
     // If we get here then no handler code was provided, or the code was
     // empty.
     return None
@@ -636,7 +636,7 @@ object SymbolicOperator {
   def reportTime() {
     knownExecutor.console.emit("Time Compiling Native Handlers: ")
     knownExecutor.console.emitln(
-        Timeable.asTimeString(_timer.getCumulativeTimeMillis))
+      Timeable.asTimeString(_timer.getCumulativeTimeMillis))
   }
 
   /**
@@ -679,7 +679,6 @@ object SymbolicOperator {
    */
   def unapply(so: SymbolicOperator) = Some((so.name, so.theType, so.params))
 
-
   /**
    * The well-known MAP operator.  This is needed to define the types of
    * operators, but is not used to define its own type.  The type of the MAP
@@ -689,11 +688,11 @@ object SymbolicOperator {
    */
   val MAP = OperatorRef(
     SymbolicOperator(Loc.internal, "MAP", TypeUniverse, AtomSeq(NoProps,
-        'domain, 'codomain),
+      'domain, 'codomain),
       "Mapping constructor.",
       "This operator is used to construct types for operators.  It " +
-      "indicates a mapping from one type (the domain) to another type " +
-      "(the codomain)."))
+        "indicates a mapping from one type (the domain) to another type " +
+        "(the codomain)."))
 
   /**
    * The well-known cross product operator.  This is needed to define the
@@ -705,8 +704,8 @@ object SymbolicOperator {
     SymbolicOperator(Loc.internal, "xx", ANY, AtomSeq(Associative(true), 'x, 'y),
       "Cross product.",
       "This operator is used to construct types for operators.  It " +
-      "indicates the cross product of two atoms (typically types).  " +
-      "These originate from the types of the parameters of an operator."))
+        "indicates the cross product of two atoms (typically types).  " +
+        "These originate from the types of the parameters of an operator."))
 
   /**
    * The well-known list operator.  This is used to define the type of lists
@@ -717,9 +716,8 @@ object SymbolicOperator {
     SymbolicOperator(Loc.internal, "LIST", TypeUniverse, AtomSeq(NoProps, 'type),
       "List type constructor.",
       "This operator is used to indicate the type of a list.  It takes a " +
-      "single argument that is the type of the atoms in the list.  For " +
-      "heterogeneous lists this will be ANY."))
-
+        "single argument that is the type of the atoms in the list.  For " +
+        "heterogeneous lists this will be ANY."))
 
   /**
    * Compute an operator type.
@@ -755,11 +753,11 @@ object SymbolicOperator {
  */
 protected class SymbolicOperator protected (
   sfh: SpecialFormHolder,
-  name: String, 
-  typ: BasicAtom, 
+  name: String,
+  typ: BasicAtom,
   val params: AtomSeq,
-  description: String, 
-  detail: String, 
+  description: String,
+  detail: String,
   evenMeta: Boolean,
   val handlertxt: Option[String])
   extends Operator(sfh, name, typ, params, description, detail, evenMeta) {
@@ -768,7 +766,7 @@ protected class SymbolicOperator protected (
 
   // Check the properties.
   _check()
-  
+
   /** The native handler, if any. */
   val handler = SymbolicOperator.compileHandler(this, handlertxt)
 
@@ -887,7 +885,7 @@ protected class SymbolicOperator protected (
 
   /**
    * All symbolic operator applications arrive here to get resolved.
-   * 
+   *
    * @param rhs     The right-hand side (arguments).
    * @param bypass  If true, bypass any native handler.
    * @return  The constructed atom.
@@ -898,7 +896,7 @@ protected class SymbolicOperator protected (
     if (BasicAtom.rewriteTimedOut) {
       BasicAtom.timeoutTime.value = -1L
     } else {
-      BasicAtom.timeoutTime.value = Platform.currentTime + 10*1000
+      BasicAtom.timeoutTime.value = Platform.currentTime + 10 * 1000
     }
 
     rhs match {
@@ -907,248 +905,227 @@ protected class SymbolicOperator protected (
         // the argument list by flattening associative applications.  Second
         // we reduce by looking for identities, etc.  Third we check for an
         // empty argument list.
-        
+
         // Save the properties for fast access.
         val props = params.props
         val assoc = props.isA(false)
-        val commu = props.isC(false)
-        val idemp = props.isI(false)
-        val absor = props.absorber.getOrElse(null)
         val ident = props.identity.getOrElse(null)
-        
-        // Run through the arguments and watch for the absorber, omit
-        // identities, and flatten associative lists.
-        var newseq = args.atoms
-        var index = 0
-      
-        // The args AtomSeq has already done some of the following
-        // processing. Only do the while() loop if additional
-        // processing is needed.
-        val diffProps = params.props != args.props
-        var flattened_a = false
-        if (diffProps || (assoc && (args.hasOperator(this)))) {
 
+        // The args AtomSeq may have the same properties as the operator.
+        // If it does, we use it as-is, otherwise, apply the operator's
+        // properties
+        val diffProps = (props != args.props)
+        val newargs = if (diffProps) AtomSeq(props, args.atoms) else args
+        val opcount = newargs.operatorCount(this)
+        var newseq = newargs.atoms
+
+        // Flatten associative lists if it contains this operator.
+        if (assoc && opcount > 0) {
           // While loops are significantly faster than for comprehensions.
-          while (index < newseq.size) {
+          // We are searching this Operator's arguments to find more instances
+          // of this Operator to flatten out. We check how many we've found vs.
+          // how many we know are in the sequence. Once we've found them all we
+          // can cease looping.
+          var index = 0
+          var opsfound = 0
+          while (opsfound < opcount && index < newseq.size) {
             val atom = newseq(index)
-            if (diffProps && (absor == atom)) {
-              // Resume timing out rewrites.
-              BasicAtom.timeoutTime.value = oldTimeout
-              
-              // Found the absorber.  Nothing else to do.
-              return absor
-            }
-            
-            // Omit identities and check for associative lists to flatten.  If
-            // we remove an identity, do not increment the index.  If we insert
-            // items, we should not increment the index.  If we don't change the
-            // item at the current index, then we can advance the index pointer.
-            if (diffProps && (ident == atom)) {
-              newseq = newseq.omit(index)
-            } 
-            else if (assoc) atom match {
-              //case OpApply(opref, opargs, binds) if (opref.operator == this) =>
-              case OpApply(opref, opargs, binds) if (opref.operator.name == this.name) =>
+            atom match {
+              case OpApply(opref, opargs, _) if (opref.operator.name == this.name) =>
                 // Add the arguments directly to this list.  We can assume the
                 // sub-list has already been processed, so no deeper checking
                 // is needed.  This flattens associative lists, as required.
                 newseq = newseq.omit(index)
                 newseq = newseq.insert(index, opargs)
-                flattened_a = true
+                opsfound += 1
               case _ =>
                 // Nothing to do except increment the pointer.
                 index += 1
-            } 
-            else {
-              // Since nothing at this position changed, increment the pointer.
-              index += 1
             }
-          } // Run through all arguments.
-          // If this sequence is associative and commutative we need to sort it
-          // after flattening it.
-          if(flattened_a && assoc && commu){
-            newseq = newseq.sorted(BasicAtomComparator)
+          }
+          // We flattened the list, adding new arguments, so if this is
+          // commutative we need to sort
+          if (props.isC(false)) newseq = newseq.sorted(BasicAtomComparator)
+        }
+
+        // Handle actual operator application.
+        def handleApply(binds: Bindings): BasicAtom = {
+          // Re-package the arguments with the correct properties.
+          val newargs = AtomSeq(props, newseq)
+          // See if we are bypassing the native handler.
+          var r: BasicAtom = null
+          if (!bypass) {
+            // Run any native handler.            
+            if (handler.isDefined) {
+              val ad = new ApplyData(this, newargs, binds)
+              r = handler.get(ad)
+              return r
+            }
+          }
+          // No native handler.
+          r = OpApply(OperatorRef(this), newargs, binds)
+          return r
+        }
+
+        // Check the argument length versus the parameter length.
+        if (!assoc) {
+          // The number of arguments must exactly match the number of
+          // parameters.
+          if (newseq.length > params.length) {
+            throw new ArgumentListException(rhs.loc,
+              "Too many arguments for non-associative operator " +
+                toESymbol(name) + ".  Expected " + params.length +
+                " but got " + newseq.length + ".")
+          } else if (newseq.length < params.length) {
+            throw new ArgumentListException(rhs.loc,
+              "Too few arguments for non-associative operator " +
+                toESymbol(name) + ".  Expected " + params.length +
+                " but got " + newseq.length + ".")
+          }
+        } else {
+          // There are special cases to handle here.  First, if the argument
+          // list is empty, but there is an identity, return it.  Second, if
+          // the argument list is empty, but there is no identity, apply the
+          // operator to the empty list.
+          if (newseq.length == 0) {
+            if (ident == null) {
+              val r = handleApply(Bindings())
+
+              // Resume timing out rewrites.
+              BasicAtom.timeoutTime.value = oldTimeout
+              return r
+            } else {
+              // Resume timing out rewrites.
+              BasicAtom.timeoutTime.value = oldTimeout
+              return ident
+            }
           }
         }
 
-      // Handle actual operator application.
-      def handleApply(binds : Bindings): BasicAtom = {
-        // Re-package the arguments with the correct properties.
-        val newargs = AtomSeq(params.props, newseq)
-        // See if we are bypassing the native handler.
-        var r : BasicAtom = null
-        if (!bypass) {
-          // Run any native handler.            
-          if (handler.isDefined) {
-            val ad = new ApplyData(this, newargs, binds)
-            r = handler.get(ad)
-            return r
-          }
-        }
-        // No native handler.
-        r = OpApply(OperatorRef(this), newargs, binds)
-        return r
-      }
-      
-      // Check the argument length versus the parameter length.
-      if (!assoc) {
-        // The number of arguments must exactly match the number of
-        // parameters.
-        if (newseq.length > params.length) {
-          throw new ArgumentListException(rhs.loc,
-                                          "Too many arguments for non-associative operator " +
-                                          toESymbol(name) + ".  Expected " + params.length +
-                                          " but got " + newseq.length + ".")
-        } else if (newseq.length < params.length) {
-          throw new ArgumentListException(rhs.loc,
-                                          "Too few arguments for non-associative operator " +
-                                          toESymbol(name) + ".  Expected " + params.length +
-                                          " but got " + newseq.length + ".")
-        }
-      } else {
-        // There are special cases to handle here.  First, if the argument
-        // list is empty, but there is an identity, return it.  Second, if
-        // the argument list is empty, but there is no identity, apply the
-        // operator to the empty list.
-        if (newseq.length == 0) {
-          if (ident == null) {
-            val r = handleApply(Bindings())
-            
-            // Resume timing out rewrites.
-            BasicAtom.timeoutTime.value = oldTimeout
-            return r
-          } else {
-            // Resume timing out rewrites.
-            BasicAtom.timeoutTime.value = oldTimeout
-            return ident
-          }
-        }
-      }
-      
-      // If the argument list is associative, we have an identity, and we
-      // have a single element, then that element must match the type of
-      // the operator, and we return it.  Why is this the rule?  We want
-      // to use associative operators to mimic "var args", but don't want
-      // them to "collapse" when there is just one argument.  That is, we
-      // don't want f(x)->x when we just want a var args f.  But if we give
-      // f an identity, it is probably a mathematical operator of some kind,
-      // and we probably do want f(x)->x.  So, for now, that's the rule.
-      // For greater control, you have to use a case operator.
-      if (newseq.length == 1) {
-        if (assoc && ident != null) {
-          // Get the atom.
-          val atom = newseq(0)
-          // Match the type of the atom against the type of the parameters.
-          val param = params(0)
-          param.tryMatch(atom) match {
-            case Fail(reason, index) =>
-              // The argument is invalid.  Reject!
-              throw new ArgumentListException(atom.loc, "Incorrect argument " +
-                                              "for operator " + toESymbol(name) + " at position 0: " +
-                                              atom.toParseString + ".  " + reason())
-            case mat: Match => {
-              // Resume timing out rewrites.
-              BasicAtom.timeoutTime.value = oldTimeout
-              
-              // The argument matches.
-              return atom
-            }
-            case many: Many => {
-              // Resume timing out rewrites.
-              BasicAtom.timeoutTime.value = oldTimeout
-              
-              // The argument matches.
-              return atom
+        // If the argument list is associative, we have an identity, and we
+        // have a single element, then that element must match the type of
+        // the operator, and we return it.  Why is this the rule?  We want
+        // to use associative operators to mimic "var args", but don't want
+        // them to "collapse" when there is just one argument.  That is, we
+        // don't want f(x)->x when we just want a var args f.  But if we give
+        // f an identity, it is probably a mathematical operator of some kind,
+        // and we probably do want f(x)->x.  So, for now, that's the rule.
+        // For greater control, you have to use a case operator.
+        if (newseq.length == 1) {
+          if (assoc && ident != null) {
+            // Get the atom.
+            val atom = newseq(0)
+            // Match the type of the atom against the type of the parameters.
+            val param = params(0)
+            param.tryMatch(atom) match {
+              case Fail(reason, index) =>
+                // The argument is invalid.  Reject!
+                throw new ArgumentListException(atom.loc, "Incorrect argument " +
+                  "for operator " + toESymbol(name) + " at position 0: " +
+                  atom.toParseString + ".  " + reason())
+              case mat: Match => {
+                // Resume timing out rewrites.
+                BasicAtom.timeoutTime.value = oldTimeout
+
+                // The argument matches.
+                return atom
+              }
+              case many: Many => {
+                // Resume timing out rewrites.
+                BasicAtom.timeoutTime.value = oldTimeout
+
+                // The argument matches.
+                return atom
+              }
             }
           }
         }
-      }
-      
-      // Is the current operator associative?
-      if (assoc) {
-        // Handle type checking of an associative operator. All
-        // formal parameters of an associative operator must have
-        // the same type, so type checking of an associative
-        // operator will be performed by checking:
-        //
-        // 1. That all arguments of the operator we are trying to
-        //    create have the same type.
-        // 2. That the type of 1 of the arguments matches the type
-        //    of 1 of the formal parameters of the associative
-        //    operator.
-        
-        // Check to see if all arguments have the same type.
-        val anArg = newseq(0)
-        /*
+
+        // Is the current operator associative?
+        if (assoc) {
+          // Handle type checking of an associative operator. All
+          // formal parameters of an associative operator must have
+          // the same type, so type checking of an associative
+          // operator will be performed by checking:
+          //
+          // 1. That all arguments of the operator we are trying to
+          //    create have the same type.
+          // 2. That the type of 1 of the arguments matches the type
+          //    of 1 of the formal parameters of the associative
+          //    operator.
+
+          // Check to see if all arguments have the same type.
+          val anArg = newseq(0)
+          /*
         if (!args.sameType) {
           throw new ArgumentListException(anArg.loc,
                                           "Not all arguments for associative operator have the same type.")
         }
         */
 
-        // All arguments have the same type. Now try to match the
-        // parameter type with the argument type. Note that the
-        // bindings returned by the match are only used for
-        // inferring the value of type variables. Since all
-        // arguments/formal parameters have the same type, matching
-        // 1 formal parameter with 1 argument gives us all the
-        // binding information needed to do type inference.
-        val aParam = params.atoms(0)
-        aParam.tryMatch(anArg) match {
-          case Fail(reason, index) =>
-            throw new ArgumentListException(anArg.loc,
-                                            "Incorrect argument for operator " + toESymbol(name) +
-                                            " at position " + index + ": " + newseq(index).toParseString +
-                                            ".  " + reason())
-          case Match(binds1) => {
-            // The argument matches.
-            val r = handleApply(binds1)
-            
-            // Resume timing out rewrites.
-            BasicAtom.timeoutTime.value = oldTimeout
-            return r
+          // All arguments have the same type. Now try to match the
+          // parameter type with the argument type. Note that the
+          // bindings returned by the match are only used for
+          // inferring the value of type variables. Since all
+          // arguments/formal parameters have the same type, matching
+          // 1 formal parameter with 1 argument gives us all the
+          // binding information needed to do type inference.
+          val aParam = params.atoms(0)
+          aParam.tryMatch(anArg) match {
+            case Fail(reason, index) =>
+              throw new ArgumentListException(anArg.loc,
+                "Incorrect argument for operator " + toESymbol(name) +
+                  " at position " + index + ": " + newseq(index).toParseString +
+                  ".  " + reason())
+            case Match(binds1) => {
+              // The argument matches.
+              val r = handleApply(binds1)
+
+              // Resume timing out rewrites.
+              BasicAtom.timeoutTime.value = oldTimeout
+              return r
+            }
+            case Many(iter) => {
+              // The argument matches.
+              val r = handleApply(iter.next)
+
+              // Resume timing out rewrites.
+              BasicAtom.timeoutTime.value = oldTimeout
+              return r
+            }
           }
-          case Many(iter) => {
-            // The argument matches.
-            val r =  handleApply(iter.next)
-            
-            // Resume timing out rewrites.
-            BasicAtom.timeoutTime.value = oldTimeout
-            return r
+        } else {
+          // We've run out of special cases to handle.  Now just try to match
+          // the arguments against the parameters.
+          val newparams = params.atoms
+          SequenceMatcher.tryMatch(newparams, newseq) match {
+            case Fail(reason, index) =>
+              throw new ArgumentListException(newseq(index).loc,
+                "Incorrect argument for operator " + toESymbol(name) +
+                  " at position " + index + ": " + newseq(index).toParseString +
+                  ".  " + reason())
+            case Match(binds1) => {
+              // The argument list matches.
+              val r = handleApply(binds1)
+
+              // Resume timing out rewrites.
+              BasicAtom.timeoutTime.value = oldTimeout
+              return r
+            }
+            case Many(iter) => {
+              // The argument list matches.
+              val r = handleApply(iter.next)
+
+              // Resume timing out rewrites.
+              BasicAtom.timeoutTime.value = oldTimeout
+              return r
+            }
           }
         }
-      } else {
-        // We've run out of special cases to handle.  Now just try to match
-        // the arguments against the parameters.
-        val newparams = params.atoms
-        SequenceMatcher.tryMatch(newparams, newseq) match {
-          case Fail(reason, index) =>
-            throw new ArgumentListException(newseq(index).loc,
-                                            "Incorrect argument for operator " + toESymbol(name) +
-                                            " at position " + index + ": " + newseq(index).toParseString +
-                                            ".  " + reason())
-          case Match(binds1) => {
-            // The argument list matches.
-            val r = handleApply(binds1)
-            
-            // Resume timing out rewrites.
-            BasicAtom.timeoutTime.value = oldTimeout
-            return r
-          }
-          case Many(iter) => {
-            // The argument list matches.
-            val r = handleApply(iter.next)
-            
-            // Resume timing out rewrites.
-            BasicAtom.timeoutTime.value = oldTimeout
-            return r
-          }
-        }
-      }
-      
+
       case _ => {
         val r = SimpleApply(this, rhs)
-        
+
         // Resume timing out rewrites.
         BasicAtom.timeoutTime.value = oldTimeout
         return r

--- a/Elision/src/ornl/elision/core/matcher/MatchHelper.scala
+++ b/Elision/src/ornl/elision/core/matcher/MatchHelper.scala
@@ -77,7 +77,8 @@ object MatchHelper {
           patterns = patterns.omit(pindex)
           subjects = subjects.omit(sindex)
       }
-    } // Omit constants from the lists.
+    }
+    
     Debugger("matching") {
       Debugger("matching", "Removing Constants: Patterns: " +
         patterns.mkParseString("", ",", ""))


### PR DESCRIPTION
- In AtomSeq, now cache both the fact that an operator exists in a associative sequence, and how many times it occurs.
- In AtomSeq, added methods access the operator counts
- In AtomSeq, made the operater cache a lazy val so that the cost of creating the HashMap isn't paid every every AtomSeq
- In AtomSeq, the cache for seen variables in idempotent sequences has also been made lazy for the same reason as above.
- In BasicAtomComparator, fcmp() now uses feq() to do its equality test, and in compare() the result of fcmp() is cached rather than called twice on the same atoms.
- In BasicAtomComparator, removed a lot of dead code.
- In Operator, removed duplication of effort from AtomSeq. Instead, generate a new AtomSeq with the Operator's properties if needed, then do the operations unique to Operator. Namely, associative flattening and commutative sorting.
- In Operator, short-circuit the associative flattening loop once we have found all the operators since we know how many there should be.
