### PR TITLE
Small bug fixes for parsing and round-trip.

### DIFF
--- a/Elision/src/ornl/elision/core/AlgProp.scala
+++ b/Elision/src/ornl/elision/core/AlgProp.scala
@@ -116,8 +116,12 @@ class AlgProp(
     case Some(atom) => atom.hashCode
   }
   
-  override lazy val otherHashCode =
-    (this.toString).foldLeft(BigInt(0))(other_hashify)+1
+  override lazy val otherHashCode: BigInt =
+    (((((_codify(associative) * 8191) +
+    _codify(identity) * 8191) +
+    _codify(idempotent) * 8191) +
+    _codify(commutative) * 8191) +
+    _codify(absorber) * 8191)
     
   override lazy val hashCode =
     (((((_codify(associative) * 12289) +

--- a/Elision/src/ornl/elision/core/AtomSeq.scala
+++ b/Elision/src/ornl/elision/core/AtomSeq.scala
@@ -182,6 +182,13 @@ class AtomSeq(val props: AlgProp, orig_xatoms: IndexedSeq[BasicAtom])
   def operatorCount(op: String): Int = {
     _operators.getOrElse(op, 0)
   }
+  
+  /**
+   * Explicitly override the toString method to force calling the method in
+   * BasicAtom; otherwise we get the method from IndexedSeq, which is not
+   * what we want.
+   */
+  override def toString = super[BasicAtom].toString
 
   /**
    * Process the atoms and build the new sequence.  This reduces any included

--- a/Elision/src/ornl/elision/core/BasicAtomComparator.scala
+++ b/Elision/src/ornl/elision/core/BasicAtomComparator.scala
@@ -117,18 +117,7 @@ object BasicAtomComparator extends Ordering[BasicAtom] {
         (if (_riskyEqual) true else other)
     )
   }
-  
 
-  
-  def fcmp(atom1: BasicAtom, atom2: BasicAtom) = {
-    if(feq(atom1, atom2, false)){
-        0
-    }
-    else {
-        atom1.hashCode compare atom2.hashCode
-    }
-  }
-  
   /**
    * Perform a comparison of optional atoms.  None is less than Some.
    * 
@@ -167,9 +156,10 @@ object BasicAtomComparator extends Ordering[BasicAtom] {
     // This explicitly breaks a potential unbounded
     // recursion caused by the LIST(x) operator.  The problems looks like this
     // (for reference): LIST(x) => LIST:OPREF . %(x), but the argument is also
-    // a LIST(x), so we have an unbounded recursion. 
-    val hashcmp = fcmp(left, right)
-    if(hashcmp == 0) return 0
+    // a LIST(x), so we have an unbounded recursion.
+    if (feq(left, right)) return 0
+    val hashcmp = left.hashCode compare right.hashCode
+    if (hashcmp == 0) return 0
     
     // Check the ordinals.
     val lo = getOrdinal(left)

--- a/Elision/src/ornl/elision/parse/EliParser.scala
+++ b/Elision/src/ornl/elision/parse/EliParser.scala
@@ -534,23 +534,25 @@ class EliParser(context: Context, source: Reader, val name: String,
     if (worker.peek() != ':') {
       naked = text
       
-      if (worker.peek() == '(') {
-        val loc = worker.loc
-        val op = context.operatorLibrary(text)
-        val args = parseNakedList("an argument list")
-        val seq = AtomSeq(AlgProp(loc), args)
-        Apply(op, seq)
-      } else {
-        text match {
-          case "true" => true
-          case "false" => false
-          case _ =>
-            val lookup = (if (text == "_") "ANY" else text)
-            NamedRootType.get(lookup) match {
-              case Some(nrt) => nrt
-              case _ => SymbolLiteral(SYMBOL, Symbol(text))
-            }
-        }
+      text match {
+        case "true" => true
+        case "false" => false
+        case _ =>
+          val lookup = (if (text == "_") "ANY" else text)
+          NamedRootType.get(lookup) match {
+            case Some(nrt) =>
+              nrt
+            case _ =>
+              if (worker.peek() == '(') {
+                val loc = worker.loc
+                val op = context.operatorLibrary(text)
+                val args = parseNakedList("an argument list")
+                val seq = AtomSeq(AlgProp(loc), args)
+                Apply(op, seq)
+              } else {
+                SymbolLiteral(SYMBOL, Symbol(text))
+              }
+          }
       }
     } else {
       naked = null
@@ -632,7 +634,7 @@ class EliParser(context: Context, source: Reader, val name: String,
         if (worker.peekAndConsume("is")) {
           // Found the keyword.  Process it.
           worker.consumeWhitespace()
-          // The percent sign is optional here
+          // The percent sign is optional here.
           ap = parseAlgebraicProperties(false)
           worker.consumeWhitespace()
         }

--- a/Elision/src/ornl/elision/repl/ERepl.scala
+++ b/Elision/src/ornl/elision/repl/ERepl.scala
@@ -471,6 +471,14 @@ extends Processor(state.settings) {
               console.error("Round trip testing failed for atom:\n  " + string +
                   "\nAtom returned by parser not equal to original:\n  " +
                   atoms(0).toParseString)
+              console.error("Original atom:  " + atom.toParseString)
+              console.error("Original atom:  " + atom.toString)
+              console.error("Original hash:  " + atom.hashCode)
+              console.error("Original other: " + atom.otherHashCode)
+              console.error("Reparsed atom:  " + atoms(0).toParseString)
+              console.error("Reparsed atom:  " + atoms(0).toString)
+              console.error("Reparsed hash:  " + atoms(0).hashCode)
+              console.error("Reparsed other: " + atoms(0).otherHashCode)
             }
         }
       }


### PR DESCRIPTION
...p problem.  Overrode the toString in AtomSeq, since it was getting the wrong one from IndexedSeq.  Folded fcmp into the atom comparator to eliminate the method.  Changed how the FastEliParser detects symbols being used as function names.  Added lots of output when round trip testing fails.
