### PR TITLE
Sorting fix and bound variable elimination expansion

### DIFF
--- a/Elision/src/ornl/elision/core/AtomSeq.scala
+++ b/Elision/src/ornl/elision/core/AtomSeq.scala
@@ -139,20 +139,28 @@ class AtomSeq(val props: AlgProp, orig_xatoms: IndexedSeq[BasicAtom])
     r
   }
   /**
-   * A map of that returns what index in a sequence a variable is located at 
+   * A map of that returns A list of indexes where a variable occurs
    */
-  lazy val variableMap: scala.collection.mutable.OpenHashMap[String, Int] = {
-    var r = scala.collection.mutable.OpenHashMap[String, Int]()
+  lazy val variableMap: scala.collection.mutable.OpenHashMap[String, List[Int]] = {
+    var r = scala.collection.mutable.OpenHashMap[String, List[Int]]()
     var i = 0
     while (i < atoms.length) {
       //if (atoms(i).isBindable) r(atoms(i)) = i
       atoms(i) match {
-        case v:Variable => r(v.name) =  i
+        case v:Variable if(r.contains(v.name)) => r(v.name) =  i +: r(v.name)
+        case v:Variable => r(v.name) = List[Int](i)
         case _ => 
       }
       i += 1
     }
     r
+  }
+  
+  lazy val variableMultiplicy: HashMap[String, (Boolean, Int, Int)] = {
+    val thing:String = ""
+    var varmul = HashMap[String, (Boolean, Int, Int)]()
+    varmul(thing) = (false, 0, 0)
+    varmul
   }
   
   /**

--- a/Elision/src/ornl/elision/core/BasicAtomComparator.scala
+++ b/Elision/src/ornl/elision/core/BasicAtomComparator.scala
@@ -180,7 +180,8 @@ object BasicAtomComparator extends Ordering[BasicAtom] {
     
     // Check the ordinals.
     val lo = getOrdinal(left)
-    var sgn = (getOrdinal(right) - lo).signum
+    val ro = getOrdinal(right)
+    var sgn = lo `compare` ro //(lo - ro).signum
     if (sgn != 0) return sgn
 
     //If we're comparing Applys, compare them based on their estimated cost to match

--- a/Elision/src/ornl/elision/core/matcher/MatchHelper.scala
+++ b/Elision/src/ornl/elision/core/matcher/MatchHelper.scala
@@ -148,12 +148,12 @@ object MatchHelper {
     binds.foreach(thing => {
       //If this variable exists in the map, get its ID. Otherwise, set -1
       //to indicate nonexistance.
-      val pomission = plist.variableMap.getOrElse(thing._1, -1)
+      val pomission = plist.variableMap.getOrElse(thing._1, List())
       // Add the pattern index to pomissions for later removal. Add the atom to
       // the subject omissions to be searched for and removed.
       // It looks like different types of bindings will need different
       // strategies for elimination. Literals are low hanging fruit.
-      if (pomission >= 0) {
+      if (pomission.length > 0) {
         def addOmission(p: Int, s: BasicAtom) {
           pomissions = p +: pomissions
           somissions = s +: somissions
@@ -161,8 +161,7 @@ object MatchHelper {
 
         thing._2 match {
           // If we have a naked atom sequence it's a peeled operator application
-          // and we can remove the atoms it contains. Make sure it's literals
-          // for the time being.
+          // and we can remove the atoms it contains. Make sure it's constant.
           case as: AtomSeq if(as.forall(p => {
             p match {
               case _:BasicAtom if(p.isConstant) => true 
@@ -170,11 +169,11 @@ object MatchHelper {
             }
           })) => {
             Debugger("constant-elimination", "Found a {AtomSeq -> constant atom sequence} constant elimination.")
-            addOmission(pomission, as)
+            pomission.foreach( om => addOmission(om, as))
           }
           case _:BasicAtom if(thing._2.isConstant) =>
             Debugger("constant-elimination", "Found a {variable -> constant} constant elimination.")
-            addOmission(pomission,thing._2)
+            pomission.foreach( om => addOmission(om,thing._2))
           case _ =>
         }
 


### PR DESCRIPTION
BasicAtomComparator had higher matching cost items sorted as less than lower matching cost items. This has been reversed so that lower matching costs items are considered less than higher matching cost items in comparisons.

variableMap now stores a list of indexes where a variable exists rather than just catching one index. Using this, bound variable elimination has been expanded to eliminate all appearances of a bound variable in an atom sequence rather than just one.
