### PR TITLE
Native Handler Key Change

### DIFF
--- a/Elision/src/ornl/elision/context/NativeCompiler.scala
+++ b/Elision/src/ornl/elision/context/NativeCompiler.scala
@@ -112,7 +112,7 @@ object NativeCompiler {
     val elision_version = (Version.major, Version.minor, Version.build)
     val versionpart = (scala_version, elision_version).hashCode.toHexString
     // Remove whitespace from the handler. We are getting a high rate
-    // of recompilationf of native handlers without this.
+    // of recompilation of native handlers without this.
     val stripped_handler = handler.replaceAll("\\s", "")
     val handlerpart = (source.trim, operator.trim,
                        stripped_handler).hashCode.toHexString

--- a/Elision/src/ornl/elision/context/NativeCompiler.scala
+++ b/Elision/src/ornl/elision/context/NativeCompiler.scala
@@ -111,7 +111,11 @@ object NativeCompiler {
     val scala_version = util.Properties.versionString
     val elision_version = (Version.major, Version.minor, Version.build)
     val versionpart = (scala_version, elision_version).hashCode.toHexString
-    val handlerpart = (source, operator, handler).hashCode.toHexString
+    // Remove whitespace from the handler. We are getting an etremely high rate
+    // of recompilationf of native handlers without this.
+    val stripped_handler = handler.replaceAll("\\s", "")
+    val handlerpart = (source.trim, operator.trim,
+                       stripped_handler).hashCode.toHexString
     val key = versionpart + handlerpart
     "NH" + key
   }

--- a/Elision/src/ornl/elision/context/NativeCompiler.scala
+++ b/Elision/src/ornl/elision/context/NativeCompiler.scala
@@ -111,7 +111,7 @@ object NativeCompiler {
     val scala_version = util.Properties.versionString
     val elision_version = (Version.major, Version.minor, Version.build)
     val versionpart = (scala_version, elision_version).hashCode.toHexString
-    // Remove whitespace from the handler. We are getting an etremely high rate
+    // Remove whitespace from the handler. We are getting a high rate
     // of recompilationf of native handlers without this.
     val stripped_handler = handler.replaceAll("\\s", "")
     val handlerpart = (source.trim, operator.trim,


### PR DESCRIPTION
The hash for native handlers was causing a high rate of recompilation of native handlers. I'm not certain of the root cause, but I imagine that the formatting is being changed somewhere in the system. Removing the whitespace fixes this issue. It is conceivable that whitespace may by significant somewhere and cause a cache hit when there should be a miss, but I find this unlikely and such a problem would almost certainly be fixed my clearing the cache and letting it be rebuilt.